### PR TITLE
Fix permissions for render-all workflow

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -5,6 +5,10 @@ on:
     - cron: "19 3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   masterror:
     uses: ./.github/workflows/render-masterror.yml


### PR DESCRIPTION
## Summary
- grant write permissions in the render-all workflow so reusable jobs can push updates

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df4b212868832b914e7a5310c2bd99