### PR TITLE
Parameterize metrics workflows branch names

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -12,15 +12,21 @@ permissions:
 jobs:
   masterror:
     uses: ./.github/workflows/render-masterror.yml
+    with:
+      branch_name: ci/metrics-refresh-masterror
     secrets:
       CLASSIC: ${{ secrets.CLASSIC }}
 
   profile:
     uses: ./.github/workflows/render-profile.yml
+    with:
+      branch_name: ci/metrics-refresh-profile
     secrets:
       CLASSIC: ${{ secrets.CLASSIC }}
 
   telegram_webapp_sdk:
     uses: ./.github/workflows/render-telegram-webapp-sdk.yml
+    with:
+      branch_name: ci/metrics-refresh-telegram-webapp-sdk
     secrets:
       CLASSIC: ${{ secrets.CLASSIC }}

--- a/.github/workflows/render-masterror.yml
+++ b/.github/workflows/render-masterror.yml
@@ -2,7 +2,18 @@ name: Render metrics for masterror repository
 
 on:
   workflow_dispatch:
+    inputs:
+      branch_name:
+        description: "Branch name used for the metrics refresh PR."
+        required: false
+        default: "ci/metrics-refresh-masterror"
   workflow_call:
+    inputs:
+      branch_name:
+        description: "Branch name used for the metrics refresh PR."
+        required: false
+        default: "ci/metrics-refresh-masterror"
+        type: string
     secrets:
       CLASSIC:
         required: true
@@ -16,7 +27,7 @@ jobs:
 
     env:
       TZ: Asia/Ho_Chi_Minh
-      BRANCH_NAME: ci/metrics-refresh
+      BRANCH_NAME: ${{ inputs.branch_name }}
       TARGET_OWNER: RAprogramm
       TARGET_REPO: masterror
       TARGET_PATH: metrics/masterror.svg

--- a/.github/workflows/render-profile.yml
+++ b/.github/workflows/render-profile.yml
@@ -2,7 +2,18 @@ name: Render metrics for RAprogramm profile
 
 on:
   workflow_dispatch:
+    inputs:
+      branch_name:
+        description: "Branch name used for the metrics refresh PR."
+        required: false
+        default: "ci/metrics-refresh-profile"
   workflow_call:
+    inputs:
+      branch_name:
+        description: "Branch name used for the metrics refresh PR."
+        required: false
+        default: "ci/metrics-refresh-profile"
+        type: string
     secrets:
       CLASSIC:
         required: true
@@ -16,7 +27,7 @@ jobs:
 
     env:
       TZ: Asia/Ho_Chi_Minh
-      BRANCH_NAME: ci/metrics-refresh
+      BRANCH_NAME: ${{ inputs.branch_name }}
       TARGET_USER: RAprogramm
       TARGET_PATH: metrics/profile.svg
       TEMP_ARTIFACT: profile.tmp.svg

--- a/.github/workflows/render-telegram-webapp-sdk.yml
+++ b/.github/workflows/render-telegram-webapp-sdk.yml
@@ -2,7 +2,18 @@ name: Render metrics for telegram-webapp-sdk repository
 
 on:
   workflow_dispatch:
+    inputs:
+      branch_name:
+        description: "Branch name used for the metrics refresh PR."
+        required: false
+        default: "ci/metrics-refresh-telegram-webapp-sdk"
   workflow_call:
+    inputs:
+      branch_name:
+        description: "Branch name used for the metrics refresh PR."
+        required: false
+        default: "ci/metrics-refresh-telegram-webapp-sdk"
+        type: string
     secrets:
       CLASSIC:
         required: true
@@ -16,7 +27,7 @@ jobs:
 
     env:
       TZ: Asia/Ho_Chi_Minh
-      BRANCH_NAME: ci/metrics-refresh
+      BRANCH_NAME: ${{ inputs.branch_name }}
       TARGET_OWNER: RAprogramm
       TARGET_REPO: telegram-webapp-sdk
       TARGET_PATH: metrics/telegram-webapp-sdk.svg


### PR DESCRIPTION
## Summary
- add a configurable `branch_name` input to each metrics rendering workflow with distinct defaults
- pass explicit branch names from the aggregate workflow to avoid collisions between concurrent runs

## Testing
- Not run (workflow configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68df50e87fa4832ba29a5003aabf146a