### PR TITLE
fix: drop deprecated cache input from metrics workflows

### DIFF
--- a/.github/workflows/render-profile.yml
+++ b/.github/workflows/render-profile.yml
@@ -51,7 +51,6 @@ jobs:
           config_octicon: yes
           config_timezone: ${{ env.TZ }}
           config_twemoji: yes
-          cache: 12h
           plugin_achievements: yes
           plugin_achievements_display: detailed
           plugin_achievements_secrets: yes

--- a/.github/workflows/render-repository.yml
+++ b/.github/workflows/render-repository.yml
@@ -75,7 +75,6 @@ jobs:
           filename: ${{ env.TEMP_ARTIFACT }}
           base: "header, activity, community, metadata"
           config_timezone: ${{ env.TZ }}
-          cache: 12h
           plugin_lines: yes
           plugin_followup: yes
           plugin_followup_sections: repositories, user


### PR DESCRIPTION
## Summary
- remove the deprecated `cache` input from the profile workflow
- drop the same unsupported input from the reusable repository workflow to avoid annotations

## Testing
- not run (workflows only)


------
https://chatgpt.com/codex/tasks/task_e_68df5bd39a04832b8376e8460c64f13e