### PR TITLE
feat: add reusable workflow for open-source metrics

### DIFF
--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -10,10 +10,10 @@ permissions:
   pull-requests: write
 
 jobs:
-  masterror:
-    uses: ./.github/workflows/render-masterror.yml
+  open_source:
+    uses: ./.github/workflows/render-open-source.yml
     with:
-      branch_name: ci/metrics-refresh-masterror
+      repositories: '["masterror", "telegram-webapp-sdk"]'
     secrets:
       CLASSIC: ${{ secrets.CLASSIC }}
 
@@ -21,12 +21,5 @@ jobs:
     uses: ./.github/workflows/render-profile.yml
     with:
       branch_name: ci/metrics-refresh-profile
-    secrets:
-      CLASSIC: ${{ secrets.CLASSIC }}
-
-  telegram_webapp_sdk:
-    uses: ./.github/workflows/render-telegram-webapp-sdk.yml
-    with:
-      branch_name: ci/metrics-refresh-telegram-webapp-sdk
     secrets:
       CLASSIC: ${{ secrets.CLASSIC }}

--- a/.github/workflows/render-open-source.yml
+++ b/.github/workflows/render-open-source.yml
@@ -1,0 +1,38 @@
+name: Render metrics for open-source repositories
+
+on:
+  workflow_dispatch:
+    inputs:
+      repositories:
+        description: >-
+          JSON array with repository names that should be refreshed.
+          Defaults to ["masterror", "telegram-webapp-sdk"].
+        required: false
+        default: '["masterror", "telegram-webapp-sdk"]'
+  workflow_call:
+    inputs:
+      repositories:
+        description: >-
+          JSON array with repository names that should be refreshed.
+          Defaults to ["masterror", "telegram-webapp-sdk"].
+        required: false
+        type: string
+        default: '["masterror", "telegram-webapp-sdk"]'
+    secrets:
+      CLASSIC:
+        required: true
+
+jobs:
+  render:
+    strategy:
+      matrix:
+        repository: ${{ fromJSON(inputs.repositories != '' ? inputs.repositories : '["masterror", "telegram-webapp-sdk"]') }}
+    uses: ./.github/workflows/render-repository.yml
+    with:
+      branch_name: ${{ format('ci/metrics-refresh-{0}', matrix.repository) }}
+      target_owner: RAprogramm
+      target_repo: ${{ matrix.repository }}
+      target_path: ${{ format('metrics/{0}.svg', matrix.repository) }}
+      temp_artifact: ${{ format('.metrics-tmp/{0}.svg', matrix.repository) }}
+    secrets:
+      CLASSIC: ${{ secrets.CLASSIC }}

--- a/README.md
+++ b/README.md
@@ -21,3 +21,19 @@ jobs:
 ```
 
 The workflow automatically renders the repository metrics card, commits the refreshed SVG to the configured path, and opens an idempotent pull request when changes are detected.
+
+### Open-source repositories bundle
+
+Workflows targeting public repositories that live under the `RAprogramm` organization can reuse `.github/workflows/render-open-source.yml`. The workflow accepts a JSON array with repository names and renders the standard repository dashboard for each entry.
+
+```yaml
+jobs:
+  open_source:
+    uses: RAprogramm/infra-metrics-insight-renderer/.github/workflows/render-open-source.yml@main
+    with:
+      repositories: '["masterror", "telegram-webapp-sdk"]'
+    secrets:
+      CLASSIC: ${{ secrets.METRICS_TOKEN }}
+```
+
+Providing a custom list of repositories allows a single job to refresh multiple metrics cards without duplicating boilerplate workflow definitions.


### PR DESCRIPTION
## Summary
- add reusable workflow that renders repository metrics for a JSON-defined list of open-source repos
- switch the aggregated render workflow to call the reusable open-source renderer
- document how to trigger metrics refreshes for multiple repositories at once

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df64babf20832baacb9ededbb7d1ba