### PR TITLE
Fix metrics actions to use prebuilt image

### DIFF
--- a/.github/actions/render-profile/action.yml
+++ b/.github/actions/render-profile/action.yml
@@ -102,6 +102,7 @@ runs:
     - name: Metrics embed
       uses: lowlighter/metrics@v3.34
       with:
+        use_prebuilt_image: yes
         token: ${{ inputs.classic_token }}
         user: ${{ env.TARGET_USER }}
         template: classic

--- a/.github/actions/render-repository/action.yml
+++ b/.github/actions/render-repository/action.yml
@@ -102,6 +102,7 @@ runs:
     - name: Metrics embed
       uses: lowlighter/metrics@v3.34
       with:
+        use_prebuilt_image: yes
         token: ${{ inputs.classic_token }}
         user: ${{ env.TARGET_OWNER }}
         repo: ${{ env.TARGET_REPO }}


### PR DESCRIPTION
## Summary
- configure the composite actions to request the prebuilt lowlighter/metrics Docker image, avoiding local rebuilds during workflow runs

## Testing
- cargo +nightly fmt --manifest-path metrics-orchestrator/Cargo.toml
- cargo clippy --all-targets --manifest-path metrics-orchestrator/Cargo.toml -- -D warnings
- cargo build --all-targets --manifest-path metrics-orchestrator/Cargo.toml
- cargo test --all --manifest-path metrics-orchestrator/Cargo.toml
- cargo doc --no-deps --manifest-path metrics-orchestrator/Cargo.toml
- (cd metrics-orchestrator && cargo audit)
- cargo deny --manifest-path metrics-orchestrator/Cargo.toml check

------
https://chatgpt.com/codex/tasks/task_e_68df71d94230832ba2689c0af441913c