### PR TITLE
Use prebuilt lowlighter metrics container

### DIFF
--- a/.github/actions/render-profile/action.yml
+++ b/.github/actions/render-profile/action.yml
@@ -105,6 +105,7 @@ runs:
         token: ${{ inputs.classic_token }}
         user: ${{ env.TARGET_USER }}
         template: classic
+        use_prebuilt_image: ghcr.io/lowlighter/metrics:v3.34.0
         filename: ${{ env.TEMP_ARTIFACT }}
         base: "header, activity, community, repositories, metadata"
         base_hireable: yes

--- a/.github/actions/render-repository/action.yml
+++ b/.github/actions/render-repository/action.yml
@@ -106,6 +106,7 @@ runs:
         user: ${{ env.TARGET_OWNER }}
         repo: ${{ env.TARGET_REPO }}
         template: repository
+        use_prebuilt_image: ghcr.io/lowlighter/metrics:v3.34.0
         filename: ${{ env.TEMP_ARTIFACT }}
         base: "header, activity, community, metadata"
         config_timezone: ${{ env.TIME_ZONE }}


### PR DESCRIPTION
## Summary
- configure the render-profile composite action to use the pinned prebuilt lowlighter/metrics container image
- configure the render-repository composite action to use the pinned prebuilt lowlighter/metrics container image

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo deny check
- cargo audit

------
https://chatgpt.com/codex/tasks/task_e_68df71eab938832bba41769de08e43ef