### PR TITLE
Fix composite actions by removing duplicate metrics image parameter

### DIFF
--- a/.github/actions/render-profile/action.yml
+++ b/.github/actions/render-profile/action.yml
@@ -106,7 +106,6 @@ runs:
         token: ${{ inputs.classic_token }}
         user: ${{ env.TARGET_USER }}
         template: classic
-        use_prebuilt_image: ghcr.io/lowlighter/metrics:v3.34.0
         filename: ${{ env.TEMP_ARTIFACT }}
         base: "header, activity, community, repositories, metadata"
         base_hireable: yes

--- a/.github/actions/render-repository/action.yml
+++ b/.github/actions/render-repository/action.yml
@@ -107,7 +107,6 @@ runs:
         user: ${{ env.TARGET_OWNER }}
         repo: ${{ env.TARGET_REPO }}
         template: repository
-        use_prebuilt_image: ghcr.io/lowlighter/metrics:v3.34.0
         filename: ${{ env.TEMP_ARTIFACT }}
         base: "header, activity, community, metadata"
         config_timezone: ${{ env.TIME_ZONE }}


### PR DESCRIPTION
## Summary
- remove the duplicated `use_prebuilt_image` entries from the composite actions so GitHub no longer rejects their manifests

## Testing
- cargo +nightly fmt --
- cargo clippy -- -D warnings
- cargo build --all-targets
- cargo test --all
- cargo doc --no-deps
- cargo audit
- cargo deny check -c ../deny.toml

------
https://chatgpt.com/codex/tasks/task_e_68df7d5641dc832baf075af17bc413d4