### PR TITLE
Fix here-doc invocation in render workflow

### DIFF
--- a/.github/workflows/render-open-source.yml
+++ b/.github/workflows/render-open-source.yml
@@ -34,7 +34,7 @@ jobs:
           RAW_INPUT: ${{ inputs.repositories }}
         run: |
           set -euo pipefail
-          python - <<'PY' "${GITHUB_OUTPUT}"
+          python - "${GITHUB_OUTPUT}" <<'PY'
 import json
 import os
 import sys


### PR DESCRIPTION
## Summary
- correct the here-doc invocation in the render workflow so the Python script receives the output path argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df841f3b64832b95dc0eb2441bd7c5