### PR TITLE
Add infra metrics target configuration and regression test

### DIFF
--- a/metrics-orchestrator/src/normalizer.rs
+++ b/metrics-orchestrator/src/normalizer.rs
@@ -219,6 +219,38 @@ mod tests {
     }
 
     #[test]
+    fn normalizes_infra_metrics_insight_renderer_target() {
+        let entry = TargetEntry {
+            owner: "RAprogramm".to_owned(),
+            repository: Some("infra-metrics-insight-renderer".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: Some("infra-metrics-insight-renderer".to_owned()),
+            branch_name: None,
+            target_path: None,
+            temp_artifact: None,
+            time_zone: None,
+            display_name: Some("Infra Metrics Insight Renderer".to_owned()),
+        };
+
+        let target = normalize_entry(&entry).expect("expected target to normalize");
+        assert_eq!(target.slug, "infra-metrics-insight-renderer");
+        assert_eq!(
+            target.branch_name,
+            "ci/metrics-refresh-infra-metrics-insight-renderer"
+        );
+        assert_eq!(
+            target.target_path,
+            "metrics/infra-metrics-insight-renderer.svg"
+        );
+        assert_eq!(
+            target.temp_artifact,
+            ".metrics-tmp/infra-metrics-insight-renderer.svg"
+        );
+        assert_eq!(target.time_zone, "Asia/Ho_Chi_Minh");
+        assert_eq!(target.display_name, "Infra Metrics Insight Renderer");
+    }
+
+    #[test]
     fn normalizes_profile_entry_with_overrides() {
         let entry = TargetEntry {
             owner: " Octocat ".to_owned(),

--- a/targets/targets.yaml
+++ b/targets/targets.yaml
@@ -11,3 +11,8 @@ targets:
   - owner: RAprogramm
     repository: telegram-webapp-sdk
     type: open_source
+  - owner: RAprogramm
+    repository: infra-metrics-insight-renderer
+    type: open_source
+    slug: infra-metrics-insight-renderer
+    display_name: Infra Metrics Insight Renderer


### PR DESCRIPTION
## Summary
- add the infra-metrics-insight-renderer open-source target configuration with the desired slug and display name
- add a regression test that normalizes the new target and verifies the derived branch, paths, time zone, and display name

## Testing
- RUSTUP_TOOLCHAIN=nightly scripts/ci-check.sh

------
https://chatgpt.com/codex/tasks/task_e_68df88b1f97c832b9a4fd5bb26048e58