### PR TITLE
Add workflow to render infra-metrics-insight-renderer metrics card

### DIFF
--- a/.github/workflows/render-infra-metrics-insight-renderer.yml
+++ b/.github/workflows/render-infra-metrics-insight-renderer.yml
@@ -1,0 +1,31 @@
+name: Render metrics for infra-metrics-insight-renderer repository
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: "Branch name used for the metrics refresh PR."
+        required: false
+        default: "ci/metrics-refresh-infra-metrics-insight-renderer"
+  workflow_call:
+    inputs:
+      branch_name:
+        description: "Branch name used for the metrics refresh PR."
+        required: false
+        default: "ci/metrics-refresh-infra-metrics-insight-renderer"
+        type: string
+    secrets:
+      CLASSIC:
+        required: true
+
+jobs:
+  render:
+    uses: ./.github/workflows/render-repository.yml
+    with:
+      branch_name: ${{ inputs.branch_name }}
+      target_owner: RAprogramm
+      target_repo: infra-metrics-insight-renderer
+      target_path: metrics/infra-metrics-insight-renderer.svg
+      temp_artifact: .metrics-tmp/infra-metrics-insight-renderer.svg
+    secrets:
+      CLASSIC: ${{ secrets.CLASSIC }}


### PR DESCRIPTION
## Summary
- add a render workflow for the infra-metrics-insight-renderer repository that reuses the shared repository workflow

## Testing
- RUSTUP_TOOLCHAIN=1.90.0 scripts/ci-check.sh

------
https://chatgpt.com/codex/tasks/task_e_68df88b97f78832ba8f363a26d326862