### PR TITLE
Fix heredoc indentation in render workflow

### DIFF
--- a/.github/workflows/render-open-source.yml
+++ b/.github/workflows/render-open-source.yml
@@ -34,32 +34,31 @@ jobs:
           RAW_INPUT: ${{ inputs.repositories }}
         run: |
           set -euo pipefail
-          python - "${GITHUB_OUTPUT}" <<'PY'
-            import json
-            import os
-            import sys
+          python - <<'PY'
+import json
+import os
 
-            output_path = sys.argv[1]
-            raw = os.environ.get("RAW_INPUT", "").strip()
-            if not raw:
-                raw = '["masterror", "telegram-webapp-sdk"]'
-            try:
-                repositories = json.loads(raw)
-            except json.JSONDecodeError as exc:
-                raise SystemExit(f"Invalid repositories JSON: {exc}") from exc
-            if not isinstance(repositories, list) or not repositories:
-                raise SystemExit("Repositories input must be a non-empty JSON array of repository names.")
-            normalized = []
-            for item in repositories:
-                if not isinstance(item, str):
-                    raise SystemExit("Repositories input must contain only strings.")
-                trimmed = item.strip()
-                if not trimmed:
-                    raise SystemExit("Repository names cannot be empty strings.")
-                normalized.append(trimmed)
-            with open(output_path, "a", encoding="utf-8") as handle:
-                handle.write(f"repositories={json.dumps(normalized)}\n")
-          PY
+output_path = os.environ["GITHUB_OUTPUT"]
+raw = os.environ.get("RAW_INPUT", "").strip()
+if not raw:
+    raw = '["masterror", "telegram-webapp-sdk"]'
+try:
+    repositories = json.loads(raw)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"Invalid repositories JSON: {exc}") from exc
+if not isinstance(repositories, list) or not repositories:
+    raise SystemExit("Repositories input must be a non-empty JSON array of repository names.")
+normalized = []
+for item in repositories:
+    if not isinstance(item, str):
+        raise SystemExit("Repositories input must contain only strings.")
+    trimmed = item.strip()
+    if not trimmed:
+        raise SystemExit("Repository names cannot be empty strings.")
+    normalized.append(trimmed)
+with open(output_path, "a", encoding="utf-8") as handle:
+    handle.write(f"repositories={json.dumps(normalized)}\n")
+PY
 
   render:
     needs: prepare


### PR DESCRIPTION
## Summary
- run the Python helper script via heredoc without extra indentation so the workflow YAML parses correctly

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df8ea6ff70832bbbb240b5d7f5c90d