### PR TITLE
Support branch overrides in target configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ cargo run --manifest-path metrics-orchestrator/Cargo.toml -- --config targets/ta
 The command outputs the normalized JSON document that the workflow uses. The same CLI is invoked during CI, so validation errors
 must be resolved locally before a workflow run succeeds.
 
+Optional per-target overrides include:
+
+- `branch_name` (or the alias `branch`) – select the Git branch used for the metrics refresh pull request.
+- `target_path` – change where the rendered SVG is stored.
+- `temp_artifact` – adjust the temporary filename produced by the renderer before moving it into place.
+- `time_zone` – customize the time zone passed to the renderer.
+- `slug` – override the derived slug used for filenames and workflow dispatch names.
+
+Unset overrides fall back to deterministic defaults chosen by the orchestrator, so adding a new target only requires the owner,
+repository (when applicable), and target type.
+
 ## IMIR badge integration
 
 Register a repository or profile by adding a new entry to [`targets/targets.yaml`](targets/targets.yaml). The orchestrator

--- a/metrics-orchestrator/src/config.rs
+++ b/metrics-orchestrator/src/config.rs
@@ -33,7 +33,7 @@ pub struct TargetEntry
     pub slug: Option<String,>,
 
     /// Optional branch name override for commits with refreshed metrics.
-    #[serde(default)]
+    #[serde(default, alias = "branch", alias = "branch-name", alias = "branchName")]
     pub branch_name: Option<String,>,
 
     /// Optional destination path override for the generated SVG artifact.

--- a/metrics-orchestrator/src/normalizer.rs
+++ b/metrics-orchestrator/src/normalizer.rs
@@ -377,6 +377,22 @@ mod tests
     }
 
     #[test]
+    fn parse_targets_supports_branch_alias()
+    {
+        let yaml = r#"
+            targets:
+              - owner: octocat
+                repository: metrics
+                type: open_source
+                branch:  feature/metrics 
+        "#;
+
+        let document = parse_targets(yaml,).expect("expected parse success",);
+        assert_eq!(document.targets.len(), 1);
+        assert_eq!(document.targets[0].branch_name, "feature/metrics");
+    }
+
+    #[test]
     fn parse_targets_propagates_decode_errors()
     {
         let result = parse_targets("targets: invalid",);

--- a/targets/targets.yaml
+++ b/targets/targets.yaml
@@ -5,6 +5,7 @@ targets:
   - owner: RAprogramm
     type: profile
     slug: profile
+    # branch: ci/metrics-refresh-profile
   - owner: RAprogramm
     repository: masterror
     type: open_source


### PR DESCRIPTION
## Summary
- allow target definitions to specify the metrics refresh branch via the new `branch`/`branch-name`/`branchName` aliases
- document available per-target overrides and provide an inline example for configuring a custom branch
- cover the branch alias parsing behaviour with a unit test

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy --manifest-path metrics-orchestrator/Cargo.toml --all-targets -- -D warnings
- cargo +1.90.0 build --manifest-path metrics-orchestrator/Cargo.toml --all-targets
- cargo +1.90.0 test --manifest-path metrics-orchestrator/Cargo.toml --all
- cargo +1.90.0 doc --manifest-path metrics-orchestrator/Cargo.toml --no-deps
- cargo audit
- cargo deny check -c ../deny.toml


------
https://chatgpt.com/codex/tasks/task_e_68df8b8470e4832bbec1d1eb8570fcd6