### PR TITLE
Add contributors branch configuration

### DIFF
--- a/.github/actions/render-repository/action.yml
+++ b/.github/actions/render-repository/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Branch name used for commits with refreshed metrics.
     required: false
     default: ''
+  contributors_branch:
+    description: Branch analyzed by the contributors plugin.
+    required: false
+    default: ''
   target_path:
     description: Destination path for the generated metrics artifact relative to the repo root.
     required: false
@@ -76,6 +80,25 @@ runs:
           BRANCH_NAME="ci/metrics-refresh-${TARGET_REPO}"
         fi
 
+        CONTRIBUTORS_BRANCH_INPUT="${{ inputs.contributors_branch }}"
+        if [ -n "${CONTRIBUTORS_BRANCH_INPUT}" ]; then
+          CONTRIBUTORS_BRANCH="$(printf '%s' "${CONTRIBUTORS_BRANCH_INPUT}" | xargs)"
+        else
+          CONTRIBUTORS_BRANCH="main"
+        fi
+
+        if [ -z "${CONTRIBUTORS_BRANCH}" ]; then
+          echo "The contributors_branch input cannot be empty." >&2
+          exit 1
+        fi
+
+        case "${CONTRIBUTORS_BRANCH}" in
+          *[[:space:]]*)
+            echo "The contributors_branch input cannot contain whitespace." >&2
+            exit 1
+            ;;
+        esac
+
         TIME_ZONE_INPUT="${{ inputs.time_zone }}"
         if [ -n "${TIME_ZONE_INPUT}" ]; then
           TIME_ZONE="${TIME_ZONE_INPUT}"
@@ -88,6 +111,7 @@ runs:
         echo "TARGET_PATH=${TARGET_PATH}" >> "${GITHUB_ENV}"
         echo "TEMP_ARTIFACT=${TEMP_ARTIFACT}" >> "${GITHUB_ENV}"
         echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_ENV}"
+        echo "CONTRIBUTORS_BRANCH=${CONTRIBUTORS_BRANCH}" >> "${GITHUB_ENV}"
         echo "TIME_ZONE=${TIME_ZONE}" >> "${GITHUB_ENV}"
 
     - name: Checkout renderer
@@ -116,6 +140,8 @@ runs:
         plugin_projects: no
         plugin_licenses: yes
         plugin_contributors: yes
+        plugin_contributors_head: ${{ env.CONTRIBUTORS_BRANCH }}
+        plugin_contributors_base: ${{ env.CONTRIBUTORS_BRANCH }}
 
     - name: Locate generated artifact
       id: artifact

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -92,6 +92,7 @@ jobs:
           target_owner: ${{ matrix.target.owner }}
           target_repo: ${{ matrix.target.repository }}
           branch_name: ${{ matrix.target.branch_name }}
+          contributors_branch: ${{ matrix.target.contributors_branch }}
           target_path: ${{ matrix.target.target_path }}
           temp_artifact: ${{ matrix.target.temp_artifact }}
           time_zone: ${{ matrix.target.time_zone }}

--- a/.github/workflows/render-infra-metrics-insight-renderer.yml
+++ b/.github/workflows/render-infra-metrics-insight-renderer.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/render-repository.yml
     with:
       branch_name: ${{ inputs.branch_name }}
+      contributors_branch: main
       target_owner: RAprogramm
       target_repo: infra-metrics-insight-renderer
       target_path: metrics/infra-metrics-insight-renderer.svg

--- a/.github/workflows/render-masterror.yml
+++ b/.github/workflows/render-masterror.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/render-repository.yml
     with:
       branch_name: ${{ inputs.branch_name }}
+      contributors_branch: main
       target_owner: RAprogramm
       target_repo: masterror
       target_path: metrics/masterror.svg

--- a/.github/workflows/render-open-source.yml
+++ b/.github/workflows/render-open-source.yml
@@ -81,5 +81,6 @@ PY
           target_owner: RAprogramm
           target_repo: ${{ matrix.repository }}
           branch_name: ${{ format('ci/metrics-refresh-{0}', matrix.repository) }}
+          contributors_branch: main
           target_path: ${{ format('metrics/{0}.svg', matrix.repository) }}
           temp_artifact: ${{ format('.metrics-tmp/{0}.svg', matrix.repository) }}

--- a/.github/workflows/render-repository.yml
+++ b/.github/workflows/render-repository.yml
@@ -19,10 +19,17 @@ on:
       temp_artifact:
         description: "Intermediate artifact filename produced by metrics renderer."
         required: false
+      contributors_branch:
+        description: "Repository branch analyzed by contributors plugin."
+        required: false
   workflow_call:
     inputs:
       branch_name:
         description: "Branch name used for the metrics refresh PR."
+        required: false
+        type: string
+      contributors_branch:
+        description: "Repository branch analyzed by contributors plugin."
         required: false
         type: string
       target_owner:
@@ -64,5 +71,6 @@ jobs:
           target_owner: ${{ inputs.target_owner || github.repository_owner }}
           target_repo: ${{ inputs.target_repo }}
           branch_name: ${{ inputs.branch_name || format('ci/metrics-refresh-{0}', inputs.target_repo) }}
+          contributors_branch: ${{ inputs.contributors_branch }}
           target_path: ${{ inputs.target_path || format('metrics/{0}.svg', inputs.target_repo) }}
           temp_artifact: ${{ inputs.temp_artifact || format('.metrics-tmp/{0}.svg', inputs.target_repo) }}

--- a/.github/workflows/render-telegram-webapp-sdk.yml
+++ b/.github/workflows/render-telegram-webapp-sdk.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/render-repository.yml
     with:
       branch_name: ${{ inputs.branch_name }}
+      contributors_branch: main
       target_owner: RAprogramm
       target_repo: telegram-webapp-sdk
       target_path: metrics/telegram-webapp-sdk.svg

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ jobs:
     with:
       target_repo: my-repository
       # branch_name: ci/metrics-refresh-my-repository
+      # contributors_branch: main
       # target_owner: RAprogramm
       # target_path: metrics/my-repository.svg
       # temp_artifact: .metrics-tmp/my-repository.svg
@@ -72,6 +73,7 @@ Optional per-target overrides include:
 - `branch_name` (or the alias `branch`) – select the Git branch used for the metrics refresh pull request.
 - `target_path` – change where the rendered SVG is stored.
 - `temp_artifact` – adjust the temporary filename produced by the renderer before moving it into place.
+- `contributors_branch` – specify the repository branch analyzed by the contributors plugin.
 - `time_zone` – customize the time zone passed to the renderer.
 - `slug` – override the derived slug used for filenames and workflow dispatch names.
 

--- a/metrics-orchestrator/src/config.rs
+++ b/metrics-orchestrator/src/config.rs
@@ -36,6 +36,15 @@ pub struct TargetEntry
     #[serde(default, alias = "branch", alias = "branch-name", alias = "branchName")]
     pub branch_name: Option<String,>,
 
+    /// Optional branch name analyzed by the contributors plugin.
+    #[serde(
+        default,
+        alias = "contributors_branch",
+        alias = "contributors-branch",
+        alias = "contributorsBranch"
+    )]
+    pub contributors_branch: Option<String,>,
+
     /// Optional destination path override for the generated SVG artifact.
     #[serde(default)]
     pub target_path: Option<String,>,
@@ -108,6 +117,7 @@ mod tests
             target_type:   TargetKind::OpenSource,
             slug:          Some("  Custom Slug  ".to_owned(),),
             branch_name:   None,
+            contributors_branch: None,
             target_path:   None,
             temp_artifact: None,
             time_zone:     None,
@@ -127,6 +137,7 @@ mod tests
             target_type:   TargetKind::Profile,
             slug:          None,
             branch_name:   None,
+            contributors_branch: None,
             target_path:   None,
             temp_artifact: None,
             time_zone:     None,
@@ -146,6 +157,7 @@ mod tests
             target_type:   TargetKind::PrivateProject,
             slug:          None,
             branch_name:   None,
+            contributors_branch: None,
             target_path:   None,
             temp_artifact: None,
             time_zone:     None,
@@ -165,6 +177,7 @@ mod tests
             target_type:   TargetKind::OpenSource,
             slug:          None,
             branch_name:   None,
+            contributors_branch: None,
             target_path:   None,
             temp_artifact: None,
             time_zone:     None,
@@ -183,6 +196,7 @@ mod tests
             target_type:   TargetKind::OpenSource,
             slug:          None,
             branch_name:   None,
+            contributors_branch: None,
             target_path:   None,
             temp_artifact: None,
             time_zone:     None,
@@ -202,6 +216,7 @@ mod tests
             target_type:   TargetKind::OpenSource,
             slug:          None,
             branch_name:   None,
+            contributors_branch: None,
             target_path:   None,
             temp_artifact: None,
             time_zone:     None,
@@ -221,6 +236,7 @@ mod tests
             target_type:   TargetKind::Profile,
             slug:          None,
             branch_name:   None,
+            contributors_branch: None,
             target_path:   None,
             temp_artifact: None,
             time_zone:     None,

--- a/targets/targets.yaml
+++ b/targets/targets.yaml
@@ -9,11 +9,14 @@ targets:
   - owner: RAprogramm
     repository: masterror
     type: open_source
+    contributors_branch: main
   - owner: RAprogramm
     repository: telegram-webapp-sdk
     type: open_source
+    contributors_branch: main
   - owner: RAprogramm
     repository: infra-metrics-insight-renderer
     type: open_source
     slug: infra-metrics-insight-renderer
     display_name: Infra Metrics Insight Renderer
+    contributors_branch: main


### PR DESCRIPTION
## Summary
- allow repository workflows and action to accept a contributors_branch override and wire it through the matrix runs
- default RA repositories to use the main branch for contributor analysis and document the new option

## Testing
- cargo +nightly fmt --manifest-path metrics-orchestrator/Cargo.toml
- cargo +nightly clippy --manifest-path metrics-orchestrator/Cargo.toml -- -D warnings
- cargo +nightly build --all-targets --manifest-path metrics-orchestrator/Cargo.toml
- cargo +nightly test --manifest-path metrics-orchestrator/Cargo.toml --all
- cargo +nightly doc --no-deps --manifest-path metrics-orchestrator/Cargo.toml
- cargo audit
- cargo deny --manifest-path metrics-orchestrator/Cargo.toml check

------
https://chatgpt.com/codex/tasks/task_e_68df921c25dc832b9753fcbf643772f9