### PR TITLE
Document orchestrator APIs

### DIFF
--- a/metrics-orchestrator/src/config.rs
+++ b/metrics-orchestrator/src/config.rs
@@ -1,28 +1,52 @@
+//! Configuration document types describing metrics renderer targets.
+//!
+//! The types in this module mirror the structure of the YAML documents
+//! consumed by the orchestrator CLI. They intentionally keep optional values
+//! flexible to allow user-supplied overrides, and provide helper methods for
+//! deriving normalized values that satisfy downstream invariants.
+
 use serde::Deserialize;
 
 use crate::slug::SlugStrategy;
 
 /// Root configuration document describing all targets that should be rendered.
-#[derive(Debug, Deserialize,)]
-pub struct TargetConfig
-{
+///
+/// # Examples
+///
+/// ```
+/// use metrics_orchestrator::TargetConfig;
+///
+/// let yaml = r#"
+/// targets:
+///   - owner: octocat
+///     repo: hello-world
+///     type: open_source
+/// "#;
+/// let config: TargetConfig = serde_yaml::from_str(yaml,).expect("valid configuration",);
+/// assert_eq!(config.targets.len(), 1);
+/// ```
+#[derive(Debug, Deserialize)]
+pub struct TargetConfig {
     /// Collection of metrics targets to render.
     #[serde(default)]
-    pub targets: Vec<TargetEntry,>,
+    pub targets: Vec<TargetEntry>,
 }
 
 /// Raw configuration entry describing a single metrics target before
 /// normalization.
-#[derive(Debug, Deserialize, Clone,)]
-pub struct TargetEntry
-{
+///
+/// Instances are typically created by deserializing YAML documents. Helper
+/// methods are provided to derive slugs and display names in a consistent
+/// manner.
+#[derive(Debug, Deserialize, Clone)]
+pub struct TargetEntry {
     /// GitHub account that owns the repository or profile.
     #[serde(alias = "user")]
     pub owner: String,
 
     /// Optional repository name associated with the target.
     #[serde(default, alias = "repo")]
-    pub repository: Option<String,>,
+    pub repository: Option<String>,
 
     /// Logical target type that influences renderer presets.
     #[serde(rename = "type")]
@@ -30,201 +54,225 @@ pub struct TargetEntry
 
     /// Optional slug override used for filenames and branch names.
     #[serde(default)]
-    pub slug: Option<String,>,
+    pub slug: Option<String>,
 
     /// Optional branch name override for commits with refreshed metrics.
     #[serde(default, alias = "branch", alias = "branch-name", alias = "branchName")]
-    pub branch_name: Option<String,>,
+    pub branch_name: Option<String>,
 
     /// Optional destination path override for the generated SVG artifact.
     #[serde(default)]
-    pub target_path: Option<String,>,
+    pub target_path: Option<String>,
 
     /// Optional temporary artifact override produced by the renderer.
     #[serde(default)]
-    pub temp_artifact: Option<String,>,
+    pub temp_artifact: Option<String>,
 
     /// Optional timezone override for renderer inputs.
     #[serde(default)]
-    pub time_zone: Option<String,>,
+    pub time_zone: Option<String>,
 
     /// Optional display name override used in commit messages.
     #[serde(default)]
-    pub display_name: Option<String,>,
+    pub display_name: Option<String>,
 }
 
-impl TargetEntry
-{
-    /// Returns the slug that should be used for this target, normalizing
-    /// optional user-provided overrides when present.
-    pub fn resolved_slug(&self,) -> Option<String,>
-    {
-        if let Some(custom,) = self.slug.as_ref() {
-            return SlugStrategy::builder(custom,).build();
+impl TargetEntry {
+    /// Returns the slug that should be used for this target.
+    ///
+    /// Custom overrides are normalized through [`SlugStrategy`] while
+    /// fallbacks are derived based on the target type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use metrics_orchestrator::{TargetEntry, TargetKind};
+    ///
+    /// let entry = TargetEntry {
+    ///     owner: "octocat".to_owned(),
+    ///     repository: Some("metrics".to_owned(),),
+    ///     target_type: TargetKind::OpenSource,
+    ///     slug: None,
+    ///     branch_name: None,
+    ///     target_path: None,
+    ///     temp_artifact: None,
+    ///     time_zone: None,
+    ///     display_name: None,
+    /// };
+    /// assert_eq!(entry.resolved_slug().as_deref(), Some("metrics"));
+    /// ```
+    pub fn resolved_slug(&self) -> Option<String> {
+        if let Some(custom) = self.slug.as_ref() {
+            return SlugStrategy::builder(custom).build();
         }
 
         match self.target_type {
             TargetKind::Profile => {
                 let derived = format!("{}-profile", self.owner);
-                SlugStrategy::builder(&derived,).build()
+                SlugStrategy::builder(&derived).build()
             }
-            TargetKind::OpenSource | TargetKind::PrivateProject => {
-                self.repository.as_ref().and_then(|name| SlugStrategy::builder(name,).build(),)
-            }
+            TargetKind::OpenSource | TargetKind::PrivateProject => self
+                .repository
+                .as_ref()
+                .and_then(|name| SlugStrategy::builder(name).build()),
         }
     }
 
     /// Provides the display name used for commit messages and logging.
-    pub fn resolved_display_name(&self,) -> Option<String,>
-    {
-        if let Some(name,) = self.display_name.as_ref() {
+    ///
+    /// Leading and trailing whitespace is trimmed. When no override is
+    /// supplied, the value falls back to "profile" or the repository name.
+    pub fn resolved_display_name(&self) -> Option<String> {
+        if let Some(name) = self.display_name.as_ref() {
             let trimmed = name.trim();
             if trimmed.is_empty() {
                 return None;
             }
-            return Some(trimmed.to_owned(),);
+            return Some(trimmed.to_owned());
         }
 
         match self.target_type {
-            TargetKind::Profile => Some("profile".to_owned(),),
+            TargetKind::Profile => Some("profile".to_owned()),
             TargetKind::OpenSource | TargetKind::PrivateProject => {
-                self.repository.as_ref().map(|repo| repo.trim().to_owned(),)
+                self.repository.as_ref().map(|repo| repo.trim().to_owned())
             }
         }
     }
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use super::{TargetEntry, TargetKind};
 
     #[test]
-    fn resolved_slug_prefers_custom_value()
-    {
+    fn resolved_slug_prefers_custom_value() {
         let entry = TargetEntry {
-            owner:         "octocat".to_owned(),
-            repository:    Some("Hello-World".to_owned(),),
-            target_type:   TargetKind::OpenSource,
-            slug:          Some("  Custom Slug  ".to_owned(),),
-            branch_name:   None,
-            target_path:   None,
+            owner: "octocat".to_owned(),
+            repository: Some("Hello-World".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: Some("  Custom Slug  ".to_owned()),
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  None,
+            time_zone: None,
+            display_name: None,
         };
 
-        let slug = entry.resolved_slug().expect("expected slug to be derived from override",);
+        let slug = entry
+            .resolved_slug()
+            .expect("expected slug to be derived from override");
         assert_eq!(slug, "custom-slug");
     }
 
     #[test]
-    fn resolved_slug_falls_back_to_profile_default()
-    {
+    fn resolved_slug_falls_back_to_profile_default() {
         let entry = TargetEntry {
-            owner:         "octocat".to_owned(),
-            repository:    None,
-            target_type:   TargetKind::Profile,
-            slug:          None,
-            branch_name:   None,
-            target_path:   None,
+            owner: "octocat".to_owned(),
+            repository: None,
+            target_type: TargetKind::Profile,
+            slug: None,
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  None,
+            time_zone: None,
+            display_name: None,
         };
 
-        let slug = entry.resolved_slug().expect("expected slug to be derived from owner",);
+        let slug = entry
+            .resolved_slug()
+            .expect("expected slug to be derived from owner");
         assert_eq!(slug, "octocat-profile");
     }
 
     #[test]
-    fn resolved_slug_falls_back_to_repository_name()
-    {
+    fn resolved_slug_falls_back_to_repository_name() {
         let entry = TargetEntry {
-            owner:         "octocat".to_owned(),
-            repository:    Some("Example Repo".to_owned(),),
-            target_type:   TargetKind::PrivateProject,
-            slug:          None,
-            branch_name:   None,
-            target_path:   None,
+            owner: "octocat".to_owned(),
+            repository: Some("Example Repo".to_owned()),
+            target_type: TargetKind::PrivateProject,
+            slug: None,
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  None,
+            time_zone: None,
+            display_name: None,
         };
 
-        let slug = entry.resolved_slug().expect("expected slug to be derived from repository",);
+        let slug = entry
+            .resolved_slug()
+            .expect("expected slug to be derived from repository");
         assert_eq!(slug, "example-repo");
     }
 
     #[test]
-    fn resolved_slug_returns_none_when_unable_to_derive()
-    {
+    fn resolved_slug_returns_none_when_unable_to_derive() {
         let entry = TargetEntry {
-            owner:         "octocat".to_owned(),
-            repository:    Some("***".to_owned(),),
-            target_type:   TargetKind::OpenSource,
-            slug:          None,
-            branch_name:   None,
-            target_path:   None,
+            owner: "octocat".to_owned(),
+            repository: Some("***".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: None,
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  None,
+            time_zone: None,
+            display_name: None,
         };
 
         assert!(entry.resolved_slug().is_none());
     }
 
     #[test]
-    fn resolved_display_name_prefers_override()
-    {
+    fn resolved_display_name_prefers_override() {
         let entry = TargetEntry {
-            owner:         "octocat".to_owned(),
-            repository:    Some("repo".to_owned(),),
-            target_type:   TargetKind::OpenSource,
-            slug:          None,
-            branch_name:   None,
-            target_path:   None,
+            owner: "octocat".to_owned(),
+            repository: Some("repo".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: None,
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  Some("  Friendly Name  ".to_owned(),),
+            time_zone: None,
+            display_name: Some("  Friendly Name  ".to_owned()),
         };
 
-        let display = entry.resolved_display_name().expect("expected display name to be derived",);
+        let display = entry
+            .resolved_display_name()
+            .expect("expected display name to be derived");
         assert_eq!(display, "Friendly Name");
     }
 
     #[test]
-    fn resolved_display_name_uses_repository_name()
-    {
+    fn resolved_display_name_uses_repository_name() {
         let entry = TargetEntry {
-            owner:         "octocat".to_owned(),
-            repository:    Some(" Repo With Spaces ".to_owned(),),
-            target_type:   TargetKind::OpenSource,
-            slug:          None,
-            branch_name:   None,
-            target_path:   None,
+            owner: "octocat".to_owned(),
+            repository: Some(" Repo With Spaces ".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: None,
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  None,
+            time_zone: None,
+            display_name: None,
         };
 
-        let display = entry.resolved_display_name().expect("expected repository name to be used",);
+        let display = entry
+            .resolved_display_name()
+            .expect("expected repository name to be used");
         assert_eq!(display, "Repo With Spaces");
     }
 
     #[test]
-    fn resolved_display_name_returns_none_when_override_blank()
-    {
+    fn resolved_display_name_returns_none_when_override_blank() {
         let entry = TargetEntry {
-            owner:         "octocat".to_owned(),
-            repository:    None,
-            target_type:   TargetKind::Profile,
-            slug:          None,
-            branch_name:   None,
-            target_path:   None,
+            owner: "octocat".to_owned(),
+            repository: None,
+            target_type: TargetKind::Profile,
+            slug: None,
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  Some("   ".to_owned(),),
+            time_zone: None,
+            display_name: Some("   ".to_owned()),
         };
 
         assert!(entry.resolved_display_name().is_none());
@@ -232,10 +280,9 @@ mod tests
 }
 
 /// Supported categories of metrics targets.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize,)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum TargetKind
-{
+pub enum TargetKind {
     /// Render a GitHub profile dashboard.
     Profile,
     /// Render an open-source repository dashboard.

--- a/metrics-orchestrator/src/error.rs
+++ b/metrics-orchestrator/src/error.rs
@@ -1,88 +1,92 @@
 #![allow(non_shorthand_field_patterns)]
-// The derive emitted by `masterror::Error` expands pattern matches that trip
-// `non_shorthand_field_patterns`, so we disable the lint for this module.
+#![doc = "Error handling primitives shared across the orchestrator crate."]
+//! The derive emitted by [`masterror::Error`] expands pattern matches that
+//! trigger the `non_shorthand_field_patterns` lint. The lint is disabled for
+//! the module to keep the generated implementations warning-free while still
+//! exposing a thoroughly documented error surface for library consumers.
 
 use std::path::{Path, PathBuf};
 
 /// Unified error type returned by the configuration loader and CLI.
-#[derive(Debug, masterror::Error,)]
-pub enum Error
-{
+///
+/// Each variant captures sufficient context for diagnostics while avoiding
+/// accidental exposure of sensitive data. Instances are typically constructed
+/// through the [`io_error`] helper or by converting from serde error types via
+/// the provided `From` implementations.
+#[derive(Debug, masterror::Error)]
+pub enum Error {
     /// Wraps I/O errors that occur while reading configuration files.
     #[error("failed to read configuration from {path:?}: {source}")]
-    Io
-    {
+    Io {
         /// Location of the configuration file.
-        path:   PathBuf,
+        path: PathBuf,
         /// Underlying I/O error.
         source: std::io::Error,
     },
     /// Wraps YAML decoding errors.
     #[error("failed to parse configuration: {source}")]
-    Parse
-    {
+    Parse {
         /// Source decoding error from serde_yaml.
         source: serde_yaml::Error,
     },
     /// Returned when the configuration violates invariants.
     #[error("invalid configuration: {message}")]
-    Validation
-    {
+    Validation {
         /// Human readable message describing the validation problem.
         message: String,
     },
     /// Wraps serialization errors when writing normalized output.
     #[error("failed to serialize targets: {source}")]
-    Serialize
-    {
+    Serialize {
         /// Underlying serialization error.
         source: serde_json::Error,
     },
 }
 
-impl Error
-{
+impl Error {
     /// Constructs a validation error from the provided displayable value.
-    pub fn validation<M,>(message: M,) -> Self
+    ///
+    /// # Parameters
+    ///
+    /// * `message` - Human-readable description of the validation failure.
+    pub fn validation<M>(message: M) -> Self
     where
-        M: Into<String,>,
+        M: Into<String>,
     {
         Self::Validation {
             message: message.into(),
         }
     }
 
-    /// Formats the error for diagnostics without the variant name to ease CLI
-    /// reporting.
-    pub fn to_display_string(&self,) -> String
-    {
+    /// Formats the error for diagnostics without the variant name.
+    ///
+    /// This method is primarily intended for CLI contexts where the variant
+    /// name does not add value to end users. The returned string matches the
+    /// [`std::fmt::Display`] implementation.
+    pub fn to_display_string(&self) -> String {
         format!("{self}")
     }
 }
 
-impl From<serde_yaml::Error,> for Error
-{
-    fn from(source: serde_yaml::Error,) -> Self
-    {
-        Self::Parse {
-            source,
-        }
+impl From<serde_yaml::Error> for Error {
+    fn from(source: serde_yaml::Error) -> Self {
+        Self::Parse { source }
     }
 }
 
-impl From<serde_json::Error,> for Error
-{
-    fn from(source: serde_json::Error,) -> Self
-    {
-        Self::Serialize {
-            source,
-        }
+impl From<serde_json::Error> for Error {
+    fn from(source: serde_json::Error) -> Self {
+        Self::Serialize { source }
     }
 }
 
-/// Helper function to create an [`Error::Io`] variant.
-pub fn io_error(path: &Path, source: std::io::Error,) -> Error
-{
+/// Creates an [`Error::Io`] variant capturing the failing path and source.
+///
+/// # Parameters
+///
+/// * `path` - Location of the configuration file that triggered the error.
+/// * `source` - I/O error reported by the operating system.
+pub fn io_error(path: &Path, source: std::io::Error) -> Error {
     Error::Io {
         path: path.to_path_buf(),
         source,
@@ -90,18 +94,14 @@ pub fn io_error(path: &Path, source: std::io::Error,) -> Error
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use super::Error;
 
     #[test]
-    fn validation_constructor_populates_message()
-    {
-        let error = Error::validation("something went wrong",);
+    fn validation_constructor_populates_message() {
+        let error = Error::validation("something went wrong");
         match error {
-            Error::Validation {
-                ref message,
-            } => {
+            Error::Validation { ref message } => {
                 assert_eq!(message, "something went wrong");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -109,18 +109,16 @@ mod tests
     }
 
     #[test]
-    fn to_display_string_matches_display()
-    {
-        let error = Error::validation("display me",);
+    fn to_display_string_matches_display() {
+        let error = Error::validation("display me");
         assert_eq!(error.to_string(), error.to_display_string());
     }
 
     #[test]
-    fn io_error_helper_wraps_path_and_source()
-    {
-        let path = std::path::Path::new("/tmp/example.yaml",);
-        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "missing",);
-        let error = super::io_error(path, io_error,);
+    fn io_error_helper_wraps_path_and_source() {
+        let path = std::path::Path::new("/tmp/example.yaml");
+        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let error = super::io_error(path, io_error);
 
         match error {
             Error::Io {
@@ -135,17 +133,15 @@ mod tests
     }
 
     #[test]
-    fn serde_yaml_conversion_maps_to_parse_variant()
-    {
-        let error = serde_yaml::from_str::<usize,>("not-a-number",).unwrap_err();
+    fn serde_yaml_conversion_maps_to_parse_variant() {
+        let error = serde_yaml::from_str::<usize>("not-a-number").unwrap_err();
         let mapped: Error = error.into();
         assert!(matches!(mapped, Error::Parse { .. }));
     }
 
     #[test]
-    fn serde_json_conversion_maps_to_serialize_variant()
-    {
-        let invalid = serde_json::from_str::<serde_json::Value,>("not-json",).unwrap_err();
+    fn serde_json_conversion_maps_to_serialize_variant() {
+        let invalid = serde_json::from_str::<serde_json::Value>("not-json").unwrap_err();
         let mapped: Error = invalid.into();
         assert!(matches!(mapped, Error::Serialize { .. }));
     }

--- a/metrics-orchestrator/src/lib.rs
+++ b/metrics-orchestrator/src/lib.rs
@@ -2,7 +2,9 @@
 //!
 //! The library exposes helpers that load YAML configuration files describing
 //! metrics targets and transform them into normalized descriptors suitable for
-//! driving GitHub Actions matrices.
+//! driving GitHub Actions matrices. All public APIs are documented with
+//! invariants, error semantics, and minimal examples to facilitate integration
+//! in automation tooling.
 
 mod config;
 mod error;
@@ -11,6 +13,7 @@ mod open_source;
 mod slug;
 
 pub use config::{TargetConfig, TargetEntry, TargetKind};
-pub use error::Error;
+pub use error::{io_error, Error};
 pub use normalizer::{load_targets, parse_targets, RenderTarget, TargetsDocument};
 pub use open_source::resolve_open_source_repositories;
+pub use slug::SlugStrategy;

--- a/metrics-orchestrator/src/main.rs
+++ b/metrics-orchestrator/src/main.rs
@@ -1,30 +1,39 @@
+//! Command-line interface for the metrics orchestrator binary.
+//!
+//! The CLI exposes subcommands for normalizing target configuration documents
+//! and resolving workflow inputs specific to open-source repository rendering.
+
 use std::{io, path::PathBuf, process};
 
 use clap::{ArgAction, Args, Parser, Subcommand};
 use metrics_orchestrator::{load_targets, resolve_open_source_repositories, Error};
 
 /// Command line interface for generating normalized metrics target definitions.
-#[derive(Debug, Parser,)]
-#[command(name = "metrics-orchestrator", version, about = "Normalize metrics renderer targets")]
-struct Cli
-{
+#[derive(Debug, Parser)]
+#[command(
+    name = "metrics-orchestrator",
+    version,
+    about = "Normalize metrics renderer targets"
+)]
+/// Top-level CLI options parsed from user input.
+struct Cli {
     #[command(subcommand)]
     command: Command,
 }
 
-#[derive(Debug, Subcommand,)]
-enum Command
-{
+#[derive(Debug, Subcommand)]
+/// Supported commands exposed by the CLI.
+enum Command {
     /// Normalize targets from a YAML configuration file.
-    Targets(TargetsArgs,),
+    Targets(TargetsArgs),
     /// Resolve repository inputs for the open-source render workflow.
     #[command(name = "open-source")]
-    OpenSource(OpenSourceArgs,),
+    OpenSource(OpenSourceArgs),
 }
 
-#[derive(Debug, Args,)]
-struct TargetsArgs
-{
+#[derive(Debug, Args)]
+/// Arguments accepted by the `targets` subcommand.
+struct TargetsArgs {
     /// Path to the YAML configuration file describing metrics targets.
     #[arg(long = "config", value_name = "PATH")]
     config: PathBuf,
@@ -34,63 +43,76 @@ struct TargetsArgs
     pretty: bool,
 }
 
-#[derive(Debug, Args,)]
-struct OpenSourceArgs
-{
+#[derive(Debug, Args)]
+/// Arguments accepted by the `open-source` subcommand.
+struct OpenSourceArgs {
     /// Raw repositories JSON provided by the workflow input.
     #[arg(long = "input", value_name = "JSON")]
-    input: Option<String,>,
+    input: Option<String>,
 }
 
-fn main()
-{
-    if let Err(error,) = run() {
+/// Entry point that reports errors and sets the appropriate exit status.
+fn main() {
+    if let Err(error) = run() {
         eprintln!("{}", error.to_display_string());
-        process::exit(1,);
+        process::exit(1);
     }
 }
 
-fn run() -> Result<(), Error,>
-{
+/// Executes the CLI using parsed arguments.
+///
+/// # Errors
+///
+/// Propagates errors originating from configuration loading and normalization.
+fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Targets(args,) => run_targets(args,),
-        Command::OpenSource(args,) => run_open_source(args,),
+        Command::Targets(args) => run_targets(args),
+        Command::OpenSource(args) => run_open_source(args),
     }
 }
 
-fn run_targets(args: TargetsArgs,) -> Result<(), Error,>
-{
-    let document = load_targets(&args.config,)?;
+/// Handles the `targets` subcommand by emitting normalized JSON to stdout.
+///
+/// # Errors
+///
+/// Returns an [`Error`] when the configuration cannot be loaded or serialized.
+fn run_targets(args: TargetsArgs) -> Result<(), Error> {
+    let document = load_targets(&args.config)?;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
     if args.pretty {
-        serde_json::to_writer_pretty(&mut handle, &document,)?;
+        serde_json::to_writer_pretty(&mut handle, &document)?;
     } else {
-        serde_json::to_writer(&mut handle, &document,)?;
+        serde_json::to_writer(&mut handle, &document)?;
     }
 
-    Ok((),)
+    Ok(())
 }
 
-fn run_open_source(args: OpenSourceArgs,) -> Result<(), Error,>
-{
-    let trimmed = args.input.as_deref().map(str::trim,).and_then(|value| {
+/// Handles the `open-source` subcommand by normalizing repository inputs.
+///
+/// # Errors
+///
+/// Returns an [`Error`] when repository inputs are invalid or serialization
+/// fails.
+fn run_open_source(args: OpenSourceArgs) -> Result<(), Error> {
+    let trimmed = args.input.as_deref().map(str::trim).and_then(|value| {
         if value.is_empty() {
             None
         } else {
-            Some(value,)
+            Some(value)
         }
-    },);
+    });
 
-    let repositories = resolve_open_source_repositories(trimmed,)?;
+    let repositories = resolve_open_source_repositories(trimmed)?;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    serde_json::to_writer(&mut handle, &repositories,)?;
+    serde_json::to_writer(&mut handle, &repositories)?;
 
-    Ok((),)
+    Ok(())
 }

--- a/metrics-orchestrator/src/normalizer.rs
+++ b/metrics-orchestrator/src/normalizer.rs
@@ -1,3 +1,11 @@
+//! Transformation logic that converts raw configuration entries into
+//! normalized render targets.
+//!
+//! The normalization process ensures every derived value adheres to
+//! deterministic naming rules and avoids collisions in filenames, temporary
+//! artifacts, and branch names. The resulting structures are ready for
+//! serialization into workflow matrix inputs.
+
 use std::{collections::HashSet, fs, path::Path};
 
 use serde::Serialize;
@@ -7,146 +15,176 @@ use crate::{
     error::{self, Error},
 };
 
+/// Prefix applied to branch names when no custom override is supplied.
 const DEFAULT_BRANCH_PREFIX: &str = "ci/metrics-refresh-";
+/// Directory containing published SVG artifacts by default.
 const DEFAULT_OUTPUT_DIR: &str = "metrics";
+/// Directory used to stage intermediate renderer outputs.
 const DEFAULT_TEMP_DIR: &str = ".metrics-tmp";
+/// File extension applied to generated artifacts.
 const DEFAULT_EXTENSION: &str = "svg";
+/// Default time zone for renderer execution when none is provided.
 const DEFAULT_TIME_ZONE: &str = "Asia/Ho_Chi_Minh";
 
 /// Normalized representation of a metrics target used by automation workflows.
-#[derive(Debug, Serialize, Clone, PartialEq, Eq,)]
-pub struct RenderTarget
-{
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct RenderTarget {
     /// Unique slug derived from the configuration entry.
-    pub slug:          String,
+    pub slug: String,
     /// Account that owns the repository or profile.
-    pub owner:         String,
+    pub owner: String,
     /// Optional repository associated with the target.
-    pub repository:    Option<String,>,
+    pub repository: Option<String>,
     /// Target category.
-    pub kind:          TargetKind,
+    pub kind: TargetKind,
     /// Branch name used for storing refreshed metrics commits.
-    pub branch_name:   String,
+    pub branch_name: String,
     /// Final destination path for the generated SVG artifact.
-    pub target_path:   String,
+    pub target_path: String,
     /// Temporary artifact produced by the metrics renderer.
     pub temp_artifact: String,
     /// Time zone passed to the renderer.
-    pub time_zone:     String,
+    pub time_zone: String,
     /// Display name used in commit messages and logs.
-    pub display_name:  String,
+    pub display_name: String,
 }
 
 /// Document containing all normalized targets.
-#[derive(Debug, Serialize, Clone, PartialEq, Eq,)]
-pub struct TargetsDocument
-{
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct TargetsDocument {
     /// Aggregated targets derived from the configuration.
-    pub targets: Vec<RenderTarget,>,
+    pub targets: Vec<RenderTarget>,
 }
 
 /// Loads targets from the provided YAML configuration file path.
-pub fn load_targets(path: &Path,) -> Result<TargetsDocument, Error,>
-{
-    let contents = fs::read_to_string(path,).map_err(|source| error::io_error(path, source,),)?;
-    parse_targets(&contents,)
+///
+/// # Errors
+///
+/// Returns an [`Error`] when the file cannot be read, the YAML cannot be
+/// deserialized, or the configuration violates invariants during normalization.
+pub fn load_targets(path: &Path) -> Result<TargetsDocument, Error> {
+    let contents = fs::read_to_string(path).map_err(|source| error::io_error(path, source))?;
+    parse_targets(&contents)
 }
 
 /// Parses targets from the provided YAML document string.
-pub fn parse_targets(contents: &str,) -> Result<TargetsDocument, Error,>
-{
-    let config: TargetConfig = serde_yaml::from_str(contents,)?;
+///
+/// This function is suitable for unit tests and higher-level callers that
+/// already obtained the configuration contents.
+///
+/// # Errors
+///
+/// Propagates [`Error::Parse`](Error::Parse) when the YAML cannot be decoded
+/// and [`Error::Validation`](Error::Validation) when required entries are
+/// missing.
+pub fn parse_targets(contents: &str) -> Result<TargetsDocument, Error> {
+    let config: TargetConfig = serde_yaml::from_str(contents)?;
     if config.targets.is_empty() {
-        return Err(Error::validation("configuration must include at least one target",),);
+        return Err(Error::validation(
+            "configuration must include at least one target",
+        ));
     }
 
-    normalize_targets(&config.targets,)
+    normalize_targets(&config.targets)
 }
 
-fn normalize_targets(entries: &[TargetEntry],) -> Result<TargetsDocument, Error,>
-{
-    let mut normalized = Vec::with_capacity(entries.len(),);
-    let mut seen_slugs = HashSet::with_capacity(entries.len(),);
-    let mut seen_paths = HashSet::with_capacity(entries.len(),);
-    let mut seen_temp = HashSet::with_capacity(entries.len(),);
-    let mut seen_branches = HashSet::with_capacity(entries.len(),);
+/// Normalizes raw configuration entries into a deduplicated document.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`](Error::Validation) when collisions are
+/// detected across slugs, branch names, target paths, or temporary artifacts.
+fn normalize_targets(entries: &[TargetEntry]) -> Result<TargetsDocument, Error> {
+    let mut normalized = Vec::with_capacity(entries.len());
+    let mut seen_slugs = HashSet::with_capacity(entries.len());
+    let mut seen_paths = HashSet::with_capacity(entries.len());
+    let mut seen_temp = HashSet::with_capacity(entries.len());
+    let mut seen_branches = HashSet::with_capacity(entries.len());
 
     for entry in entries {
-        let target = normalize_entry(entry,)?;
+        let target = normalize_entry(entry)?;
 
-        if !seen_slugs.insert(target.slug.clone(),) {
-            return Err(Error::validation(format!("duplicate slug '{}'", target.slug),),);
+        if !seen_slugs.insert(target.slug.clone()) {
+            return Err(Error::validation(format!(
+                "duplicate slug '{}'",
+                target.slug
+            )));
         }
-        if !seen_paths.insert(target.target_path.clone(),) {
+        if !seen_paths.insert(target.target_path.clone()) {
             return Err(Error::validation(format!(
                 "duplicate target_path '{}'",
                 target.target_path
-            ),),);
+            )));
         }
-        if !seen_temp.insert(target.temp_artifact.clone(),) {
+        if !seen_temp.insert(target.temp_artifact.clone()) {
             return Err(Error::validation(format!(
                 "duplicate temp_artifact '{}'",
                 target.temp_artifact
-            ),),);
+            )));
         }
-        if !seen_branches.insert(target.branch_name.clone(),) {
+        if !seen_branches.insert(target.branch_name.clone()) {
             return Err(Error::validation(format!(
                 "duplicate branch_name '{}'",
                 target.branch_name
-            ),),);
+            )));
         }
 
-        normalized.push(target,);
+        normalized.push(target);
     }
 
     Ok(TargetsDocument {
         targets: normalized,
-    },)
+    })
 }
 
-fn normalize_entry(entry: &TargetEntry,) -> Result<RenderTarget, Error,>
-{
-    let owner = normalize_identifier(&entry.owner, "owner",)?;
+/// Converts a raw configuration entry into a normalized render target.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`](Error::Validation) when required fields are
+/// missing or contain disallowed characters.
+fn normalize_entry(entry: &TargetEntry) -> Result<RenderTarget, Error> {
+    let owner = normalize_identifier(&entry.owner, "owner")?;
 
     let repository = match entry.target_type {
         TargetKind::Profile => None,
         TargetKind::OpenSource | TargetKind::PrivateProject => {
             let repo_name = entry.repository.as_ref().ok_or_else(|| {
-                Error::validation("repository is required for repository targets",)
-            },)?;
-            Some(normalize_identifier(repo_name, "repository",)?,)
+                Error::validation("repository is required for repository targets")
+            })?;
+            Some(normalize_identifier(repo_name, "repository")?)
         }
     };
 
     let slug = entry
         .resolved_slug()
-        .ok_or_else(|| Error::validation("unable to derive slug for target",),)?;
+        .ok_or_else(|| Error::validation("unable to derive slug for target"))?;
 
     let branch_name = match entry.branch_name.as_ref() {
-        Some(custom,) => normalize_path_like(custom, "branch_name",)?,
+        Some(custom) => normalize_path_like(custom, "branch_name")?,
         None => format!("{DEFAULT_BRANCH_PREFIX}{slug}"),
     };
 
     let target_path = match entry.target_path.as_ref() {
-        Some(custom,) => normalize_path_like(custom, "target_path",)?,
+        Some(custom) => normalize_path_like(custom, "target_path")?,
         None => format!("{DEFAULT_OUTPUT_DIR}/{slug}.{DEFAULT_EXTENSION}"),
     };
 
     let temp_artifact = match entry.temp_artifact.as_ref() {
-        Some(custom,) => normalize_path_like(custom, "temp_artifact",)?,
+        Some(custom) => normalize_path_like(custom, "temp_artifact")?,
         None => format!("{DEFAULT_TEMP_DIR}/{slug}.{DEFAULT_EXTENSION}"),
     };
 
     let time_zone = entry
         .time_zone
         .as_ref()
-        .map(|value| value.trim(),)
-        .filter(|value| !value.is_empty(),)
-        .map_or_else(|| DEFAULT_TIME_ZONE.to_owned(), |value| value.to_owned(),);
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map_or_else(|| DEFAULT_TIME_ZONE.to_owned(), |value| value.to_owned());
 
     let display_name = entry
         .resolved_display_name()
-        .ok_or_else(|| Error::validation("unable to derive display name for target",),)?;
+        .ok_or_else(|| Error::validation("unable to derive display name for target"))?;
 
     Ok(RenderTarget {
         slug,
@@ -158,33 +196,46 @@ fn normalize_entry(entry: &TargetEntry,) -> Result<RenderTarget, Error,>
         temp_artifact,
         time_zone,
         display_name,
-    },)
+    })
 }
 
-fn normalize_identifier(input: &str, field: &str,) -> Result<String, Error,>
-{
+/// Validates identifier-like fields such as owners or repositories.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`](Error::Validation) when the value is empty or
+/// contains whitespace.
+fn normalize_identifier(input: &str, field: &str) -> Result<String, Error> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
-        return Err(Error::validation(format!("{field} cannot be empty"),),);
+        return Err(Error::validation(format!("{field} cannot be empty")));
     }
-    if trimmed.chars().any(char::is_whitespace,) {
-        return Err(Error::validation(format!("{field} cannot contain whitespace"),),);
+    if trimmed.chars().any(char::is_whitespace) {
+        return Err(Error::validation(format!(
+            "{field} cannot contain whitespace"
+        )));
     }
-    Ok(trimmed.to_owned(),)
+    Ok(trimmed.to_owned())
 }
 
-fn normalize_path_like(input: &str, field: &str,) -> Result<String, Error,>
-{
+/// Validates path-like overrides supplied in the configuration.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`](Error::Validation) when the override is
+/// blank after trimming whitespace.
+fn normalize_path_like(input: &str, field: &str) -> Result<String, Error> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
-        return Err(Error::validation(format!("{field} override cannot be empty"),),);
+        return Err(Error::validation(format!(
+            "{field} override cannot be empty"
+        )));
     }
-    Ok(trimmed.to_owned(),)
+    Ok(trimmed.to_owned())
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use std::io::Write;
 
     use super::{
@@ -193,27 +244,25 @@ mod tests
     };
     use crate::config::{TargetEntry, TargetKind};
 
-    fn repository_entry() -> TargetEntry
-    {
+    fn repository_entry() -> TargetEntry {
         TargetEntry {
-            owner:         "RAprogramm".to_owned(),
-            repository:    Some("metrics".to_owned(),),
-            target_type:   TargetKind::OpenSource,
-            slug:          None,
-            branch_name:   None,
-            target_path:   None,
+            owner: "RAprogramm".to_owned(),
+            repository: Some("metrics".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: None,
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  None,
+            time_zone: None,
+            display_name: None,
         }
     }
 
     #[test]
-    fn normalizes_repository_entry()
-    {
+    fn normalizes_repository_entry() {
         let entry = repository_entry();
 
-        let target = normalize_entry(&entry,).expect("expected normalization success",);
+        let target = normalize_entry(&entry).expect("expected normalization success");
         assert_eq!(target.slug, "metrics");
         assert_eq!(target.branch_name, "ci/metrics-refresh-metrics");
         assert_eq!(target.target_path, "metrics/metrics.svg");
@@ -222,45 +271,52 @@ mod tests
     }
 
     #[test]
-    fn normalizes_infra_metrics_insight_renderer_target()
-    {
+    fn normalizes_infra_metrics_insight_renderer_target() {
         let entry = TargetEntry {
-            owner:         "RAprogramm".to_owned(),
-            repository:    Some("infra-metrics-insight-renderer".to_owned(),),
-            target_type:   TargetKind::OpenSource,
-            slug:          Some("infra-metrics-insight-renderer".to_owned(),),
-            branch_name:   None,
-            target_path:   None,
+            owner: "RAprogramm".to_owned(),
+            repository: Some("infra-metrics-insight-renderer".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: Some("infra-metrics-insight-renderer".to_owned()),
+            branch_name: None,
+            target_path: None,
             temp_artifact: None,
-            time_zone:     None,
-            display_name:  Some("Infra Metrics Insight Renderer".to_owned(),),
+            time_zone: None,
+            display_name: Some("Infra Metrics Insight Renderer".to_owned()),
         };
 
-        let target = normalize_entry(&entry,).expect("expected target to normalize",);
+        let target = normalize_entry(&entry).expect("expected target to normalize");
         assert_eq!(target.slug, "infra-metrics-insight-renderer");
-        assert_eq!(target.branch_name, "ci/metrics-refresh-infra-metrics-insight-renderer");
-        assert_eq!(target.target_path, "metrics/infra-metrics-insight-renderer.svg");
-        assert_eq!(target.temp_artifact, ".metrics-tmp/infra-metrics-insight-renderer.svg");
+        assert_eq!(
+            target.branch_name,
+            "ci/metrics-refresh-infra-metrics-insight-renderer"
+        );
+        assert_eq!(
+            target.target_path,
+            "metrics/infra-metrics-insight-renderer.svg"
+        );
+        assert_eq!(
+            target.temp_artifact,
+            ".metrics-tmp/infra-metrics-insight-renderer.svg"
+        );
         assert_eq!(target.time_zone, "Asia/Ho_Chi_Minh");
         assert_eq!(target.display_name, "Infra Metrics Insight Renderer");
     }
 
     #[test]
-    fn normalizes_profile_entry_with_overrides()
-    {
+    fn normalizes_profile_entry_with_overrides() {
         let entry = TargetEntry {
-            owner:         " Octocat ".to_owned(),
-            repository:    None,
-            target_type:   TargetKind::Profile,
-            slug:          Some(" Custom.Profile ".to_owned(),),
-            branch_name:   Some("  feature/metrics  ".to_owned(),),
-            target_path:   Some("  dashboards/profile.svg  ".to_owned(),),
-            temp_artifact: Some("  tmp/profile.svg  ".to_owned(),),
-            time_zone:     Some("  UTC  ".to_owned(),),
-            display_name:  Some("  Profile Name  ".to_owned(),),
+            owner: " Octocat ".to_owned(),
+            repository: None,
+            target_type: TargetKind::Profile,
+            slug: Some(" Custom.Profile ".to_owned()),
+            branch_name: Some("  feature/metrics  ".to_owned()),
+            target_path: Some("  dashboards/profile.svg  ".to_owned()),
+            temp_artifact: Some("  tmp/profile.svg  ".to_owned()),
+            time_zone: Some("  UTC  ".to_owned()),
+            display_name: Some("  Profile Name  ".to_owned()),
         };
 
-        let target = normalize_entry(&entry,).expect("expected overrides to be honored",);
+        let target = normalize_entry(&entry).expect("expected overrides to be honored");
         assert_eq!(target.slug, "custom-profile");
         assert_eq!(target.branch_name, "feature/metrics");
         assert_eq!(target.target_path, "dashboards/profile.svg");
@@ -270,73 +326,65 @@ mod tests
     }
 
     #[test]
-    fn rejects_missing_repository_for_repository_target()
-    {
+    fn rejects_missing_repository_for_repository_target() {
         let entry = TargetEntry {
             repository: None,
             ..repository_entry()
         };
 
-        let result = normalize_entry(&entry,);
+        let result = normalize_entry(&entry);
         assert!(result.is_err());
     }
 
     #[test]
-    fn prevents_duplicate_slugs()
-    {
+    fn prevents_duplicate_slugs() {
         let entries = vec![repository_entry(), repository_entry()];
 
-        let result = normalize_targets(&entries,);
+        let result = normalize_targets(&entries);
         assert!(result.is_err());
     }
 
     #[test]
-    fn prevents_duplicate_target_paths()
-    {
+    fn prevents_duplicate_target_paths() {
         let mut a = repository_entry();
-        a.target_path = Some("custom/path.svg".to_owned(),);
+        a.target_path = Some("custom/path.svg".to_owned());
         let mut b = repository_entry();
-        b.slug = Some("other".to_owned(),);
-        b.target_path = Some("custom/path.svg".to_owned(),);
+        b.slug = Some("other".to_owned());
+        b.target_path = Some("custom/path.svg".to_owned());
 
-        let result = normalize_targets(&[a, b,],);
+        let result = normalize_targets(&[a, b]);
         assert!(result.is_err());
     }
 
     #[test]
-    fn prevents_duplicate_temp_artifacts()
-    {
+    fn prevents_duplicate_temp_artifacts() {
         let mut a = repository_entry();
-        a.temp_artifact = Some("tmp/output.svg".to_owned(),);
+        a.temp_artifact = Some("tmp/output.svg".to_owned());
         let mut b = repository_entry();
-        b.slug = Some("other".to_owned(),);
-        b.temp_artifact = Some("tmp/output.svg".to_owned(),);
+        b.slug = Some("other".to_owned());
+        b.temp_artifact = Some("tmp/output.svg".to_owned());
 
-        let result = normalize_targets(&[a, b,],);
+        let result = normalize_targets(&[a, b]);
         assert!(result.is_err());
     }
 
     #[test]
-    fn prevents_duplicate_branch_names()
-    {
+    fn prevents_duplicate_branch_names() {
         let mut a = repository_entry();
-        a.branch_name = Some("ci/branch".to_owned(),);
+        a.branch_name = Some("ci/branch".to_owned());
         let mut b = repository_entry();
-        b.slug = Some("other".to_owned(),);
-        b.branch_name = Some("ci/branch".to_owned(),);
+        b.slug = Some("other".to_owned());
+        b.branch_name = Some("ci/branch".to_owned());
 
-        let result = normalize_targets(&[a, b,],);
+        let result = normalize_targets(&[a, b]);
         assert!(result.is_err());
     }
 
     #[test]
-    fn normalize_identifier_rejects_whitespace()
-    {
-        let error = normalize_identifier("bad value", "field",).unwrap_err();
+    fn normalize_identifier_rejects_whitespace() {
+        let error = normalize_identifier("bad value", "field").unwrap_err();
         match error {
-            Error::Validation {
-                message,
-            } => {
+            Error::Validation { message } => {
                 assert_eq!(message, "field cannot contain whitespace");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -344,13 +392,10 @@ mod tests
     }
 
     #[test]
-    fn normalize_identifier_rejects_empty()
-    {
-        let error = normalize_identifier("   ", "field",).unwrap_err();
+    fn normalize_identifier_rejects_empty() {
+        let error = normalize_identifier("   ", "field").unwrap_err();
         match error {
-            Error::Validation {
-                message,
-            } => {
+            Error::Validation { message } => {
                 assert_eq!(message, "field cannot be empty");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -358,21 +403,17 @@ mod tests
     }
 
     #[test]
-    fn normalize_path_like_trims_values()
-    {
-        let normalized = normalize_path_like("  path/value  ", "field",)
-            .expect("expected normalization success",);
+    fn normalize_path_like_trims_values() {
+        let normalized =
+            normalize_path_like("  path/value  ", "field").expect("expected normalization success");
         assert_eq!(normalized, "path/value");
     }
 
     #[test]
-    fn normalize_path_like_rejects_empty()
-    {
-        let error = normalize_path_like("   ", "field",).unwrap_err();
+    fn normalize_path_like_rejects_empty() {
+        let error = normalize_path_like("   ", "field").unwrap_err();
         match error {
-            Error::Validation {
-                message,
-            } => {
+            Error::Validation { message } => {
                 assert_eq!(message, "field override cannot be empty");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -380,15 +421,13 @@ mod tests
     }
 
     #[test]
-    fn parse_targets_rejects_empty_configuration()
-    {
-        let result = parse_targets("targets: []",);
+    fn parse_targets_rejects_empty_configuration() {
+        let result = parse_targets("targets: []");
         assert!(result.is_err());
     }
 
     #[test]
-    fn parse_targets_handles_valid_document()
-    {
+    fn parse_targets_handles_valid_document() {
         let yaml = r#"
             targets:
               - owner: octocat
@@ -396,13 +435,12 @@ mod tests
                 type: open_source
         "#;
 
-        let document = parse_targets(yaml,).expect("expected parse success",);
+        let document = parse_targets(yaml).expect("expected parse success");
         assert_eq!(document.targets.len(), 1);
     }
 
     #[test]
-    fn parse_targets_supports_branch_alias()
-    {
+    fn parse_targets_supports_branch_alias() {
         let yaml = r#"
             targets:
               - owner: octocat
@@ -411,59 +449,60 @@ mod tests
                 branch:  feature/metrics 
         "#;
 
-        let document = parse_targets(yaml,).expect("expected parse success",);
+        let document = parse_targets(yaml).expect("expected parse success");
         assert_eq!(document.targets.len(), 1);
         assert_eq!(document.targets[0].branch_name, "feature/metrics");
     }
 
     #[test]
-    fn parse_targets_propagates_decode_errors()
-    {
-        let result = parse_targets("targets: invalid",);
+    fn parse_targets_propagates_decode_errors() {
+        let result = parse_targets("targets: invalid");
         assert!(matches!(result, Err(Error::Parse { .. })));
     }
 
     #[test]
-    fn normalized_document_preserves_order()
-    {
+    fn normalized_document_preserves_order() {
         let mut first = repository_entry();
-        first.slug = Some("first".to_owned(),);
+        first.slug = Some("first".to_owned());
         let mut second = repository_entry();
-        second.slug = Some("second".to_owned(),);
+        second.slug = Some("second".to_owned());
 
-        let document =
-            normalize_targets(&[first, second,],).expect("expected normalization success",);
-        let slugs: Vec<_,> = document.targets.iter().map(|target| target.slug.as_str(),).collect();
+        let document = normalize_targets(&[first, second]).expect("expected normalization success");
+        let slugs: Vec<_> = document
+            .targets
+            .iter()
+            .map(|target| target.slug.as_str())
+            .collect();
         assert_eq!(slugs, ["first", "second"]);
     }
 
     #[test]
-    fn render_target_equality_covers_all_fields()
-    {
-        let base = normalize_entry(&repository_entry(),).expect("expected success",);
+    fn render_target_equality_covers_all_fields() {
+        let base = normalize_entry(&repository_entry()).expect("expected success");
         let mut clone = base.clone();
         assert_eq!(base, clone);
-        clone.branch_name.push_str("-extra",);
+        clone.branch_name.push_str("-extra");
         assert_ne!(base, clone);
     }
 
     #[test]
-    fn load_targets_reads_configuration_from_disk()
-    {
-        let mut file = tempfile::NamedTempFile::new().expect("expected temp file",);
-        write!(file, "targets:\n  - owner: octocat\n    repo: metrics\n    type: open_source\n")
-            .expect("expected write to succeed",);
+    fn load_targets_reads_configuration_from_disk() {
+        let mut file = tempfile::NamedTempFile::new().expect("expected temp file");
+        write!(
+            file,
+            "targets:\n  - owner: octocat\n    repo: metrics\n    type: open_source\n"
+        )
+        .expect("expected write to succeed");
 
-        let document = load_targets(file.path(),).expect("expected load to succeed",);
+        let document = load_targets(file.path()).expect("expected load to succeed");
         assert_eq!(document.targets.len(), 1);
         assert_eq!(document.targets[0].owner, "octocat");
     }
 
     #[test]
-    fn load_targets_reports_io_errors()
-    {
-        let path = std::path::Path::new("/nonexistent/config.yaml",);
-        let error = load_targets(path,).expect_err("expected io error",);
+    fn load_targets_reports_io_errors() {
+        let path = std::path::Path::new("/nonexistent/config.yaml");
+        let error = load_targets(path).expect_err("expected io error");
         assert!(matches!(error, Error::Io { .. }));
     }
 }

--- a/metrics-orchestrator/src/open_source.rs
+++ b/metrics-orchestrator/src/open_source.rs
@@ -1,6 +1,14 @@
+//! Helpers for resolving open-source repository inputs supplied to workflows.
+//!
+//! The functions in this module sanitize and validate user-supplied JSON
+//! arrays before converting them into normalized repository name lists. The
+//! sanitization ensures downstream automation cannot be tricked into
+//! referencing empty or malformed entries.
+
 use crate::error::Error;
 
-const DEFAULT_REPOSITORIES: &[&str] = &["masterror", "telegram-webapp-sdk",];
+/// Default repositories used when the workflow input is omitted.
+const DEFAULT_REPOSITORIES: &[&str] = &["masterror", "telegram-webapp-sdk"];
 
 /// Resolves the repository list for the open-source workflow input.
 ///
@@ -23,83 +31,84 @@ const DEFAULT_REPOSITORIES: &[&str] = &["masterror", "telegram-webapp-sdk",];
 /// assert_eq!(repositories, vec!["repo".to_owned()]);
 /// # Ok::<(), metrics_orchestrator::Error>(())
 /// ```
-pub fn resolve_open_source_repositories(raw_input: Option<&str,>,)
-    -> Result<Vec<String,>, Error,>
-{
+pub fn resolve_open_source_repositories(raw_input: Option<&str>) -> Result<Vec<String>, Error> {
     match raw_input.and_then(|value| {
         let trimmed = value.trim();
         if trimmed.is_empty() {
             None
         } else {
-            Some(trimmed,)
+            Some(trimmed)
         }
-    },)
-    {
-        Some(value,) => parse_user_supplied_repositories(value,),
-        None => Ok(default_repositories(),),
+    }) {
+        Some(value) => parse_user_supplied_repositories(value),
+        None => Ok(default_repositories()),
     }
 }
 
-fn parse_user_supplied_repositories(input: &str,) -> Result<Vec<String,>, Error,>
-{
-    let parsed: Vec<String,> = serde_json::from_str(input,)
-        .map_err(|error| Error::validation(format!("invalid repositories JSON: {error}"),),)?;
+/// Parses and validates repository names supplied as a JSON array.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`](Error::Validation) when the JSON is invalid,
+/// expands to an empty array, or contains blank entries.
+fn parse_user_supplied_repositories(input: &str) -> Result<Vec<String>, Error> {
+    let parsed: Vec<String> = serde_json::from_str(input)
+        .map_err(|error| Error::validation(format!("invalid repositories JSON: {error}")))?;
 
     if parsed.is_empty() {
         return Err(Error::validation(
             "repositories input must be a non-empty JSON array of repository names",
-        ),);
+        ));
     }
 
-    let mut normalized = Vec::with_capacity(parsed.len(),);
+    let mut normalized = Vec::with_capacity(parsed.len());
     for repository in parsed {
         let trimmed = repository.trim();
         if trimmed.is_empty() {
-            return Err(Error::validation("repository names cannot be empty strings",),);
+            return Err(Error::validation(
+                "repository names cannot be empty strings",
+            ));
         }
-        normalized.push(trimmed.to_owned(),);
+        normalized.push(trimmed.to_owned());
     }
 
-    Ok(normalized,)
+    Ok(normalized)
 }
 
-fn default_repositories() -> Vec<String,>
-{
-    let mut defaults = Vec::with_capacity(DEFAULT_REPOSITORIES.len(),);
+/// Returns the default repository list as owned strings.
+fn default_repositories() -> Vec<String> {
+    let mut defaults = Vec::with_capacity(DEFAULT_REPOSITORIES.len());
     for repository in DEFAULT_REPOSITORIES {
-        defaults.push((*repository).to_owned(),);
+        defaults.push((*repository).to_owned());
     }
     defaults
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use super::resolve_open_source_repositories;
 
     #[test]
-    fn falls_back_to_defaults_when_input_missing()
-    {
-        let repositories = resolve_open_source_repositories(None,).expect("expected defaults",);
-        assert_eq!(repositories, vec!["masterror".to_owned(), "telegram-webapp-sdk".to_owned()]);
+    fn falls_back_to_defaults_when_input_missing() {
+        let repositories = resolve_open_source_repositories(None).expect("expected defaults");
+        assert_eq!(
+            repositories,
+            vec!["masterror".to_owned(), "telegram-webapp-sdk".to_owned()]
+        );
     }
 
     #[test]
-    fn trims_and_normalizes_entries()
-    {
-        let repositories = resolve_open_source_repositories(Some("[\" repo \", \"another\"]",),)
-            .expect("expected normalization",);
+    fn trims_and_normalizes_entries() {
+        let repositories = resolve_open_source_repositories(Some("[\" repo \", \"another\"]"))
+            .expect("expected normalization");
         assert_eq!(repositories, vec!["repo".to_owned(), "another".to_owned()]);
     }
 
     #[test]
-    fn rejects_empty_array()
-    {
-        let error = resolve_open_source_repositories(Some("[]",),).unwrap_err();
+    fn rejects_empty_array() {
+        let error = resolve_open_source_repositories(Some("[]")).unwrap_err();
         match error {
-            crate::Error::Validation {
-                message,
-            } => {
+            crate::Error::Validation { message } => {
                 assert_eq!(
                     message,
                     "repositories input must be a non-empty JSON array of repository names"
@@ -110,13 +119,10 @@ mod tests
     }
 
     #[test]
-    fn rejects_invalid_json()
-    {
-        let error = resolve_open_source_repositories(Some("not-json",),).unwrap_err();
+    fn rejects_invalid_json() {
+        let error = resolve_open_source_repositories(Some("not-json")).unwrap_err();
         match error {
-            crate::Error::Validation {
-                message,
-            } => {
+            crate::Error::Validation { message } => {
                 assert!(message.starts_with("invalid repositories JSON:"));
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -124,13 +130,10 @@ mod tests
     }
 
     #[test]
-    fn rejects_empty_entries()
-    {
-        let error = resolve_open_source_repositories(Some("[\"\", \"repo\"]",),).unwrap_err();
+    fn rejects_empty_entries() {
+        let error = resolve_open_source_repositories(Some("[\"\", \"repo\"]")).unwrap_err();
         match error {
-            crate::Error::Validation {
-                message,
-            } => {
+            crate::Error::Validation { message } => {
                 assert_eq!(message, "repository names cannot be empty strings");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -138,10 +141,12 @@ mod tests
     }
 
     #[test]
-    fn treats_whitespace_input_as_missing()
-    {
-        let repositories = resolve_open_source_repositories(Some("   ",),)
-            .expect("expected defaults when input whitespace",);
-        assert_eq!(repositories, vec!["masterror".to_owned(), "telegram-webapp-sdk".to_owned()]);
+    fn treats_whitespace_input_as_missing() {
+        let repositories = resolve_open_source_repositories(Some("   "))
+            .expect("expected defaults when input whitespace");
+        assert_eq!(
+            repositories,
+            vec!["masterror".to_owned(), "telegram-webapp-sdk".to_owned()]
+        );
     }
 }

--- a/metrics-orchestrator/src/slug.rs
+++ b/metrics-orchestrator/src/slug.rs
@@ -1,74 +1,85 @@
+//! Utilities for deriving stable slugs from user-supplied strings.
+//!
+//! Slugs produced by this module contain only lowercase ASCII alphanumeric
+//! characters separated by single hyphens, making them suitable for branch
+//! names and filesystem paths across platforms.
+
 /// Builder for slug strings that can be used for branch names and filenames.
-#[derive(Debug, Clone, Copy,)]
-pub struct SlugStrategy<'input,>
-{
+#[derive(Debug, Clone, Copy)]
+pub struct SlugStrategy<'input> {
     source: &'input str,
 }
 
-impl<'input,> SlugStrategy<'input,>
-{
+impl<'input> SlugStrategy<'input> {
     /// Creates a new slug builder for the provided string slice.
-    pub fn builder(source: &'input str,) -> Self
-    {
-        Self {
-            source,
-        }
+    ///
+    /// The builder retains a borrowed view of the source to avoid allocations
+    /// until [`build`](Self::build) is invoked.
+    pub fn builder(source: &'input str) -> Self {
+        Self { source }
     }
 
     /// Builds a slug from the provided source string. The slug contains only
     /// lowercase ASCII alphanumeric characters and single hyphen separators.
     /// Returns `None` when the input does not contain any slug-worthy
     /// characters after normalization.
-    pub fn build(self,) -> Option<String,>
-    {
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use metrics_orchestrator::SlugStrategy;
+    ///
+    /// let slug = SlugStrategy::builder(" Docs/Overview  ",).build();
+    /// assert_eq!(slug.as_deref(), Some("docs-overview"));
+    /// ```
+    pub fn build(self) -> Option<String> {
         let trimmed = self.source.trim();
         if trimmed.is_empty() {
             return None;
         }
 
-        let mut slug = String::with_capacity(trimmed.len(),);
+        let mut slug = String::with_capacity(trimmed.len());
         let mut previous_hyphen = false;
 
         for candidate in trimmed.chars() {
             match candidate {
                 'A'..='Z' => {
-                    slug.push(candidate.to_ascii_lowercase(),);
+                    slug.push(candidate.to_ascii_lowercase());
                     previous_hyphen = false;
                 }
                 'a'..='z' | '0'..='9' => {
-                    slug.push(candidate,);
+                    slug.push(candidate);
                     previous_hyphen = false;
                 }
                 '-' | '_' | ' ' | '.' | '/' => {
                     if !previous_hyphen && !slug.is_empty() {
-                        slug.push('-',);
+                        slug.push('-');
                         previous_hyphen = true;
                     }
                 }
                 _ => {
                     if !previous_hyphen && !slug.is_empty() {
-                        slug.push('-',);
+                        slug.push('-');
                         previous_hyphen = true;
                     }
                 }
             }
         }
 
-        while slug.ends_with('-',) {
+        while slug.ends_with('-') {
             slug.pop();
         }
 
         if slug.is_empty() {
             None
         } else {
-            Some(slug,)
+            Some(slug)
         }
     }
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use proptest::prelude::*;
 
     use super::SlugStrategy;
@@ -83,25 +94,22 @@ mod tests
     }
 
     #[test]
-    fn builder_discards_invalid_and_duplicate_separators()
-    {
-        let slug = SlugStrategy::builder("  Multi--Separator__Value  ",)
+    fn builder_discards_invalid_and_duplicate_separators() {
+        let slug = SlugStrategy::builder("  Multi--Separator__Value  ")
             .build()
-            .expect("expected slug to be derived",);
+            .expect("expected slug to be derived");
         assert_eq!(slug, "multi-separator-value");
     }
 
     #[test]
-    fn builder_returns_none_for_empty_input()
-    {
+    fn builder_returns_none_for_empty_input() {
         assert!(SlugStrategy::builder("   ").build().is_none());
         assert!(SlugStrategy::builder("***").build().is_none());
     }
 
     #[test]
-    fn builder_lowercases_uppercase_characters()
-    {
-        let slug = SlugStrategy::builder("HelloWorld",).build();
+    fn builder_lowercases_uppercase_characters() {
+        let slug = SlugStrategy::builder("HelloWorld").build();
         assert_eq!(slug.as_deref(), Some("helloworld"));
     }
 }


### PR DESCRIPTION
## Summary
- add detailed module-level and item-level documentation across the orchestrator crates
- clarify error handling docs and re-export `io_error`/`SlugStrategy` for public consumption
- describe CLI subcommands and normalization helpers with error semantics and examples

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny --manifest-path metrics-orchestrator/Cargo.toml check


------
https://chatgpt.com/codex/tasks/task_e_68df9788e5d0832bad28175803a7ce6c