### PR TITLE
Support legacy metrics-orchestrator invocation

### DIFF
--- a/metrics-orchestrator/src/main.rs
+++ b/metrics-orchestrator/src/main.rs
@@ -1,30 +1,40 @@
-use std::{io, path::PathBuf, process};
+use std::{
+    io,
+    path::{Path, PathBuf},
+    process,
+};
 
 use clap::{ArgAction, Args, Parser, Subcommand};
 use metrics_orchestrator::{load_targets, resolve_open_source_repositories, Error};
 
 /// Command line interface for generating normalized metrics target definitions.
-#[derive(Debug, Parser,)]
-#[command(name = "metrics-orchestrator", version, about = "Normalize metrics renderer targets")]
-struct Cli
-{
+#[derive(Debug, Parser)]
+#[command(
+    name = "metrics-orchestrator",
+    version,
+    about = "Normalize metrics renderer targets"
+)]
+struct Cli {
+    /// Optional subcommand invoked by the user.
     #[command(subcommand)]
-    command: Command,
+    command: Option<Command>,
+
+    /// Legacy argument support for the default targets command.
+    #[command(flatten)]
+    legacy: LegacyTargetsArgs,
 }
 
-#[derive(Debug, Subcommand,)]
-enum Command
-{
+#[derive(Debug, Subcommand)]
+enum Command {
     /// Normalize targets from a YAML configuration file.
-    Targets(TargetsArgs,),
+    Targets(TargetsArgs),
     /// Resolve repository inputs for the open-source render workflow.
     #[command(name = "open-source")]
-    OpenSource(OpenSourceArgs,),
+    OpenSource(OpenSourceArgs),
 }
 
-#[derive(Debug, Args,)]
-struct TargetsArgs
-{
+#[derive(Debug, Args)]
+struct TargetsArgs {
     /// Path to the YAML configuration file describing metrics targets.
     #[arg(long = "config", value_name = "PATH")]
     config: PathBuf,
@@ -34,63 +44,116 @@ struct TargetsArgs
     pretty: bool,
 }
 
-#[derive(Debug, Args,)]
-struct OpenSourceArgs
-{
-    /// Raw repositories JSON provided by the workflow input.
-    #[arg(long = "input", value_name = "JSON")]
-    input: Option<String,>,
+/// Arguments accepted when the CLI is invoked without a subcommand.
+#[derive(Debug, Args, Default)]
+struct LegacyTargetsArgs {
+    /// Path to the YAML configuration file describing metrics targets.
+    #[arg(long = "config", value_name = "PATH")]
+    config: Option<PathBuf>,
+
+    /// Output formatted JSON for easier inspection.
+    #[arg(long = "pretty", action = ArgAction::SetTrue)]
+    pretty: bool,
 }
 
-fn main()
-{
-    if let Err(error,) = run() {
+#[derive(Debug, Args)]
+struct OpenSourceArgs {
+    /// Raw repositories JSON provided by the workflow input.
+    #[arg(long = "input", value_name = "JSON")]
+    input: Option<String>,
+}
+
+fn main() {
+    if let Err(error) = run() {
         eprintln!("{}", error.to_display_string());
-        process::exit(1,);
+        process::exit(1);
     }
 }
 
-fn run() -> Result<(), Error,>
-{
+fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Targets(args,) => run_targets(args,),
-        Command::OpenSource(args,) => run_open_source(args,),
+        Some(Command::Targets(args)) => run_targets(args),
+        Some(Command::OpenSource(args)) => run_open_source(args),
+        None => run_legacy_targets(&cli.legacy),
     }
 }
 
-fn run_targets(args: TargetsArgs,) -> Result<(), Error,>
-{
-    let document = load_targets(&args.config,)?;
+fn run_targets(args: TargetsArgs) -> Result<(), Error> {
+    run_targets_from_path(&args.config, args.pretty)
+}
+
+fn run_targets_from_path(path: &Path, pretty: bool) -> Result<(), Error> {
+    let document = load_targets(path)?;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    if args.pretty {
-        serde_json::to_writer_pretty(&mut handle, &document,)?;
+    if pretty {
+        serde_json::to_writer_pretty(&mut handle, &document)?;
     } else {
-        serde_json::to_writer(&mut handle, &document,)?;
+        serde_json::to_writer(&mut handle, &document)?;
     }
 
-    Ok((),)
+    Ok(())
 }
 
-fn run_open_source(args: OpenSourceArgs,) -> Result<(), Error,>
-{
-    let trimmed = args.input.as_deref().map(str::trim,).and_then(|value| {
+fn run_open_source(args: OpenSourceArgs) -> Result<(), Error> {
+    let trimmed = args.input.as_deref().map(str::trim).and_then(|value| {
         if value.is_empty() {
             None
         } else {
-            Some(value,)
+            Some(value)
         }
-    },);
+    });
 
-    let repositories = resolve_open_source_repositories(trimmed,)?;
+    let repositories = resolve_open_source_repositories(trimmed)?;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    serde_json::to_writer(&mut handle, &repositories,)?;
+    serde_json::to_writer(&mut handle, &repositories)?;
 
-    Ok((),)
+    Ok(())
+}
+
+fn run_legacy_targets(args: &LegacyTargetsArgs) -> Result<(), Error> {
+    let config = args
+        .config
+        .as_deref()
+        .ok_or_else(|| Error::validation("missing required --config <PATH> argument"))?;
+
+    run_targets_from_path(config, args.pretty)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use clap::Parser;
+
+    use super::{run_legacy_targets, Cli, LegacyTargetsArgs};
+
+    #[test]
+    fn cli_accepts_legacy_targets_invocation() {
+        let cli = Cli::try_parse_from(["metrics-orchestrator", "--config", "config.yaml"])
+            .expect("failed to parse CLI");
+
+        assert!(cli.command.is_none());
+        assert_eq!(cli.legacy.config.as_deref(), Some(Path::new("config.yaml")));
+        assert!(!cli.legacy.pretty);
+    }
+
+    #[test]
+    fn legacy_targets_require_config_path() {
+        let args = LegacyTargetsArgs::default();
+        let error = run_legacy_targets(&args).expect_err("expected validation error");
+
+        match error {
+            metrics_orchestrator::Error::Validation { message, .. } => {
+                assert_eq!(message, "missing required --config <PATH> argument");
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow invoking the metrics-orchestrator binary without specifying a subcommand by reusing the targets workflow
- share target normalization logic between legacy and subcommand paths and add regression tests for the CLI parser

## Testing
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny --manifest-path metrics-orchestrator/Cargo.toml check

------
https://chatgpt.com/codex/tasks/task_e_68df9902c820832b8ce48f8e6202d346