### PR TITLE
Add include_private support for profile renders

### DIFF
--- a/.github/actions/render-profile/action.yml
+++ b/.github/actions/render-profile/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: Human readable label used in commit messages.
     required: false
     default: ''
+  include_private:
+    description: Toggle inclusion of private repositories and secret achievements.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -83,12 +87,43 @@ runs:
           DISPLAY_NAME="profile"
         fi
 
+        INCLUDE_PRIVATE_INPUT="${{ inputs.include_private }}"
+        INCLUDE_PRIVATE_NORMALIZED="$(printf '%s' "${INCLUDE_PRIVATE_INPUT}" | tr '[:upper:]' '[:lower:]')"
+        case "${INCLUDE_PRIVATE_NORMALIZED}" in
+          ""|"false"|"0"|"no")
+            INCLUDE_PRIVATE="false"
+            REPOSITORIES_AFFILIATIONS="owner, organization_member"
+            PLUGIN_REPOSITORIES_AFFILIATIONS="owner, organization_member"
+            PLUGIN_ACTIVITY_VISIBILITY="public"
+            PLUGIN_CODE_VISIBILITY="public"
+            PLUGIN_ACHIEVEMENTS_SECRETS="no"
+            ;;
+          "true"|"1"|"yes")
+            INCLUDE_PRIVATE="true"
+            REPOSITORIES_AFFILIATIONS="owner, collaborator, organization_member"
+            PLUGIN_REPOSITORIES_AFFILIATIONS="owner, collaborator, organization_member"
+            PLUGIN_ACTIVITY_VISIBILITY="all"
+            PLUGIN_CODE_VISIBILITY="all"
+            PLUGIN_ACHIEVEMENTS_SECRETS="yes"
+            ;;
+          *)
+            echo "The include_private input must be a boolean value." >&2
+            exit 1
+            ;;
+        esac
+
         echo "TARGET_USER=${TARGET_USER_INPUT}" >> "${GITHUB_ENV}"
         echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_ENV}"
         echo "TARGET_PATH=${TARGET_PATH}" >> "${GITHUB_ENV}"
         echo "TEMP_ARTIFACT=${TEMP_ARTIFACT}" >> "${GITHUB_ENV}"
         echo "TIME_ZONE=${TIME_ZONE}" >> "${GITHUB_ENV}"
         echo "DISPLAY_NAME=${DISPLAY_NAME}" >> "${GITHUB_ENV}"
+        echo "INCLUDE_PRIVATE=${INCLUDE_PRIVATE}" >> "${GITHUB_ENV}"
+        echo "REPOSITORIES_AFFILIATIONS=${REPOSITORIES_AFFILIATIONS}" >> "${GITHUB_ENV}"
+        echo "PLUGIN_REPOSITORIES_AFFILIATIONS=${PLUGIN_REPOSITORIES_AFFILIATIONS}" >> "${GITHUB_ENV}"
+        echo "PLUGIN_ACTIVITY_VISIBILITY=${PLUGIN_ACTIVITY_VISIBILITY}" >> "${GITHUB_ENV}"
+        echo "PLUGIN_CODE_VISIBILITY=${PLUGIN_CODE_VISIBILITY}" >> "${GITHUB_ENV}"
+        echo "PLUGIN_ACHIEVEMENTS_SECRETS=${PLUGIN_ACHIEVEMENTS_SECRETS}" >> "${GITHUB_ENV}"
 
     - name: Checkout renderer
       uses: actions/checkout@v5
@@ -115,10 +150,10 @@ runs:
         config_octicon: yes
         config_timezone: ${{ env.TIME_ZONE }}
         config_twemoji: yes
-        repositories_affiliations: "owner, collaborator, organization_member"
+        repositories_affiliations: ${{ env.REPOSITORIES_AFFILIATIONS }}
         plugin_achievements: yes
         plugin_achievements_display: detailed
-        plugin_achievements_secrets: yes
+        plugin_achievements_secrets: ${{ env.PLUGIN_ACHIEVEMENTS_SECRETS }}
         plugin_achievements_threshold: A
         plugin_activity: yes
         plugin_activity_days: 14
@@ -126,14 +161,14 @@ runs:
         plugin_activity_limit: 5
         plugin_activity_load: 300
         plugin_activity_timestamps: yes
-        plugin_activity_visibility: all
+        plugin_activity_visibility: ${{ env.PLUGIN_ACTIVITY_VISIBILITY }}
         plugin_calendar: yes
         plugin_calendar_limit: 1
         plugin_code: yes
         plugin_code_days: 3
         plugin_code_lines: 12
         plugin_code_load: 400
-        plugin_code_visibility: all
+        plugin_code_visibility: ${{ env.PLUGIN_CODE_VISIBILITY }}
         plugin_discussions: yes
         plugin_discussions_categories: yes
         plugin_followup: yes
@@ -196,7 +231,7 @@ runs:
         plugin_repositories: yes
         plugin_repositories_featured: "RustManifest,masterror, telegram-webapp-sdk"
         plugin_repositories_order: "featured, pinned, starred, random"
-        plugin_repositories_affiliations: "owner, collaborator, organization_member"
+        plugin_repositories_affiliations: ${{ env.PLUGIN_REPOSITORIES_AFFILIATIONS }}
         plugin_skyline: yes
         plugin_skyline_compatibility: yes
         plugin_skyline_frames: 60

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@
   <li><code>contributors_branch</code> – specify the repository branch analyzed by the contributors plugin.</li>
   <li><code>time_zone</code> – customize the time zone passed to the renderer.</li>
   <li><code>slug</code> – override the derived slug used for filenames and workflow dispatch names.</li>
+  <li><code>include_private</code> – set to <code>true</code> to include private repositories and secret achievements for the target.</li>
 </ul>
 
 <p>

--- a/imir/src/config.rs
+++ b/imir/src/config.rs
@@ -84,6 +84,10 @@ pub struct TargetEntry {
     /// Optional display name override used in commit messages.
     #[serde(default)]
     pub display_name: Option<String>,
+
+    /// Optional flag that enables private repository insights when set to `true`.
+    #[serde(default)]
+    pub include_private: Option<bool>,
 }
 
 impl TargetEntry {
@@ -108,6 +112,7 @@ impl TargetEntry {
     ///     contributors_branch: None,
     ///     time_zone: None,
     ///     display_name: None,
+    ///     include_private: None,
     /// };
     /// assert_eq!(entry.resolved_slug().as_deref(), Some("metrics"));
     /// ```
@@ -167,6 +172,7 @@ mod tests {
             temp_artifact: None,
             time_zone: None,
             display_name: None,
+            include_private: None,
         };
 
         let slug = entry
@@ -188,6 +194,7 @@ mod tests {
             temp_artifact: None,
             time_zone: None,
             display_name: None,
+            include_private: None,
         };
 
         let slug = entry
@@ -209,6 +216,7 @@ mod tests {
             temp_artifact: None,
             time_zone: None,
             display_name: None,
+            include_private: None,
         };
 
         let slug = entry
@@ -230,6 +238,7 @@ mod tests {
             temp_artifact: None,
             time_zone: None,
             display_name: None,
+            include_private: None,
         };
 
         assert!(entry.resolved_slug().is_none());
@@ -248,6 +257,7 @@ mod tests {
             temp_artifact: None,
             time_zone: None,
             display_name: Some("  Friendly Name  ".to_owned()),
+            include_private: None,
         };
 
         let display = entry
@@ -269,6 +279,7 @@ mod tests {
             temp_artifact: None,
             time_zone: None,
             display_name: None,
+            include_private: None,
         };
 
         let display = entry
@@ -290,6 +301,7 @@ mod tests {
             temp_artifact: None,
             time_zone: None,
             display_name: Some("   ".to_owned()),
+            include_private: None,
         };
 
         assert!(entry.resolved_display_name().is_none());


### PR DESCRIPTION
## Summary
- add an `include_private` flag to target configuration, normalization, and tests so renderer consumers can opt into private repository data
- document the new flag in the README and expose it through the profile composite action with the appropriate lowlighter/metrics options

## Testing
- cargo +nightly fmt --
- cargo +nightly clippy --all-targets -- -D warnings
- cargo +nightly build --all-targets
- cargo +nightly test --all
- cargo +nightly doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68e054e95768832b909110da83b6d1be