### PR TITLE
Add CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install nightly toolchain for rustfmt
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Install cargo utilities
+        uses: taiki-e/install-action@v2
+        with:
+          tool: |
+            cargo-audit
+            cargo-deny
+
+      - name: Cache build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "imir -> target"
+
+      - name: Run CI validation script
+        run: ./scripts/ci-check.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release IMIR binaries
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+            extension: ""
+          - os: macos-14
+            target: aarch64-apple-darwin
+            archive: tar.gz
+            extension: ""
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: zip
+            extension: .exe
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --locked --manifest-path imir/Cargo.toml --target ${{ matrix.target }}
+
+      - name: Package binary (tar.gz)
+        if: ${{ matrix.archive == 'tar.gz' }}
+        run: |
+          set -euo pipefail
+          BIN="imir/target/${{ matrix.target }}/release/imir${{ matrix.extension }}"
+          chmod +x "${BIN}"
+          tar -C "$(dirname "${BIN}")" -czf "imir-${{ matrix.target }}.${{ matrix.archive }}" "$(basename "${BIN}")"
+
+      - name: Package binary (zip)
+        if: ${{ matrix.archive == 'zip' }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $bin = "imir/target/${{ matrix.target }}/release/imir${{ matrix.extension }}"
+          $archive = "imir-${{ matrix.target }}.${{ matrix.archive }}"
+          Compress-Archive -Path $bin -DestinationPath $archive -Force
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: imir-${{ matrix.target }}.${{ matrix.archive }}
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
   </li>
   <li><a href="#imir-cli">IMIR CLI</a></li>
   <li><a href="#local-development-workflow">Local development workflow</a></li>
+  <li><a href="#release-process">Release process</a></li>
 </ul>
 
 <p align="right"><em><a href="#top">Back to top</a></em></p>
@@ -252,6 +253,33 @@
   with the nightly toolchain, executes Clippy, builds all targets, runs tests, generates documentation, and invokes <a href="https://crates.io/crates/cargo-audit">cargo audit</a>
   and <a href="https://crates.io/crates/cargo-deny">cargo deny</a> to ensure dependency health. Install
   <a href="https://crates.io/crates/cargo-audit">cargo-audit</a> and <a href="https://crates.io/crates/cargo-deny">cargo-deny</a> beforehand to enable the security checks.
+</p>
+
+<p align="right"><em><a href="#top">Back to top</a></em></p>
+
+<h2 id="release-process">Release process</h2>
+
+<p>
+  Tagged releases publish pre-built <code>imir</code> binaries so GitHub Actions workflows can download a pinned CLI without
+  rebuilding the crate on every run. Follow this checklist to cut a new release:
+</p>
+
+<ol>
+  <li>Run <a href="scripts/ci-check.sh"><code>scripts/ci-check.sh</code></a> locally to ensure formatting, linting, tests,
+    documentation, <code>cargo audit</code>, and <code>cargo deny</code> all pass before tagging.</li>
+  <li>Create an annotated tag (for example, <code>git tag -a v0.1.0</code>) and push it to GitHub.</li>
+  <li>Draft a release in the GitHub UI, associate it with the tag, and publish it. Publishing triggers
+    <code>.github/workflows/release.yml</code>.</li>
+  <li>The workflow builds the CLI for Linux (<code>x86_64-unknown-linux-gnu</code>), macOS (<code>aarch64-apple-darwin</code>), and
+    Windows (<code>x86_64-pc-windows-msvc</code>), packages the binaries as archives named
+    <code>imir-&lt;target&gt;.tar.gz</code> or <code>imir-&lt;target&gt;.zip</code>, and uploads them to the release assets.</li>
+  <li>Update downstream workflows to download the archive that matches their runner architecture and unpack the <code>imir</code>
+    executable into their workspace.</li>
+</ol>
+
+<p>
+  Each archive contains only the compiled binary. The release workflow runs on every published release, ensuring updated
+  binaries are available immediately after a tag is promoted.
 </p>
 
 <p align="right"><em><a href="#top">Back to top</a></em></p>


### PR DESCRIPTION
## Summary
- add a CI workflow that runs the full validation script on pushes and pull requests
- add a release workflow that builds cross-platform IMIR binaries and uploads them to GitHub releases
- document the release process so maintainers know how to publish tagged builds

## Testing
- ./scripts/ci-check.sh

------
https://chatgpt.com/codex/tasks/task_e_68e06026e7d8832ba06576314af86d8a