### PR TITLE
Add badge configuration support to render targets

### DIFF
--- a/imir/src/config.rs
+++ b/imir/src/config.rs
@@ -5,7 +5,7 @@
 //! flexible to allow user-supplied overrides, and provide helper methods for
 //! deriving normalized values that satisfy downstream invariants.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::slug::SlugStrategy;
 
@@ -88,6 +88,10 @@ pub struct TargetEntry {
     /// Optional flag that enables private repository insights when set to `true`.
     #[serde(default)]
     pub include_private: Option<bool>,
+
+    /// Optional badge customization applied to the generated widget preview.
+    #[serde(default)]
+    pub badge: Option<BadgeOptions>,
 }
 
 impl TargetEntry {
@@ -113,6 +117,7 @@ impl TargetEntry {
     ///     time_zone: None,
     ///     display_name: None,
     ///     include_private: None,
+    ///     badge: None,
     /// };
     /// assert_eq!(entry.resolved_slug().as_deref(), Some("metrics"));
     /// ```
@@ -155,9 +160,117 @@ impl TargetEntry {
     }
 }
 
+/// Badge customization entry mirroring the structure of YAML configuration.
+///
+/// The badge controls the appearance of the lightweight widget rendered next
+/// to the metrics dashboard. Users can selectively override the visual style
+/// and layout attributes while inheriting sane defaults.
+///
+/// # Examples
+///
+/// ```
+/// use imir::{BadgeOptions, BadgeStyle};
+///
+/// let options = BadgeOptions {
+///     style: Some(BadgeStyle::FlatSquare),
+///     widget: None,
+/// };
+/// assert_eq!(options.style, Some(BadgeStyle::FlatSquare));
+/// ```
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BadgeOptions {
+    /// Optional visual style preset applied to the badge.
+    #[serde(default)]
+    pub style: Option<BadgeStyle>,
+
+    /// Optional widget layout overrides.
+    #[serde(default)]
+    pub widget: Option<BadgeWidgetOptions>,
+}
+
+/// Visual themes supported by the badge renderer.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum BadgeStyle {
+    /// Render the badge using the default GitHub-inspired gradient.
+    Classic,
+    /// Render the badge using a flat appearance.
+    Flat,
+    /// Render the badge using the flat-square preset.
+    FlatSquare,
+    /// Render the badge using the plastic preset popularized by shields.io.
+    Plastic,
+    /// Render the badge using the "for-the-badge" preset with uppercase text.
+    ForTheBadge,
+}
+
+/// Layout customization options for the badge widget.
+///
+/// The configuration is intentionally conservative to avoid generating
+/// widgets that violate rendering constraints. Values outside the documented
+/// ranges are rejected during deserialization.
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
+pub struct BadgeWidgetOptions {
+    /// Optional number of columns, constrained to the range `1..=4`.
+    #[serde(default, deserialize_with = "deserialize_optional_columns")]
+    pub columns: Option<u8>,
+
+    /// Optional alignment applied to the widget contents.
+    #[serde(default)]
+    pub alignment: Option<BadgeWidgetAlignment>,
+
+    /// Optional border radius, constrained to the range `0..=32` pixels.
+    #[serde(default, deserialize_with = "deserialize_optional_border_radius")]
+    pub border_radius: Option<u8>,
+}
+
+/// Horizontal alignment presets supported by the badge widget.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum BadgeWidgetAlignment {
+    /// Align contents to the leading edge of the widget.
+    Start,
+    /// Center the contents within the widget.
+    Center,
+    /// Align contents to the trailing edge of the widget.
+    End,
+}
+
+fn deserialize_optional_columns<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<u8> = Option::deserialize(deserializer)?;
+    if let Some(columns) = value {
+        if columns == 0 || columns > 4 {
+            return Err(serde::de::Error::custom(
+                "badge.widget.columns must be between 1 and 4",
+            ));
+        }
+    }
+    Ok(value)
+}
+
+fn deserialize_optional_border_radius<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<u8> = Option::deserialize(deserializer)?;
+    if let Some(radius) = value {
+        if radius > 32 {
+            return Err(serde::de::Error::custom(
+                "badge.widget.border_radius must not exceed 32",
+            ));
+        }
+    }
+    Ok(value)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{TargetEntry, TargetKind};
+    use super::{BadgeOptions, BadgeStyle, BadgeWidgetAlignment, TargetEntry, TargetKind};
 
     #[test]
     fn resolved_slug_prefers_custom_value() {
@@ -173,6 +286,7 @@ mod tests {
             time_zone: None,
             display_name: None,
             include_private: None,
+            badge: None,
         };
 
         let slug = entry
@@ -195,6 +309,7 @@ mod tests {
             time_zone: None,
             display_name: None,
             include_private: None,
+            badge: None,
         };
 
         let slug = entry
@@ -217,6 +332,7 @@ mod tests {
             time_zone: None,
             display_name: None,
             include_private: None,
+            badge: None,
         };
 
         let slug = entry
@@ -239,6 +355,7 @@ mod tests {
             time_zone: None,
             display_name: None,
             include_private: None,
+            badge: None,
         };
 
         assert!(entry.resolved_slug().is_none());
@@ -258,6 +375,7 @@ mod tests {
             time_zone: None,
             display_name: Some("  Friendly Name  ".to_owned()),
             include_private: None,
+            badge: None,
         };
 
         let display = entry
@@ -280,6 +398,7 @@ mod tests {
             time_zone: None,
             display_name: None,
             include_private: None,
+            badge: None,
         };
 
         let display = entry
@@ -302,9 +421,56 @@ mod tests {
             time_zone: None,
             display_name: Some("   ".to_owned()),
             include_private: None,
+            badge: None,
         };
 
         assert!(entry.resolved_display_name().is_none());
+    }
+
+    #[test]
+    fn badge_options_supports_alignment_presets() {
+        let yaml = r#"
+            style: plastic
+            widget:
+              alignment: center
+              columns: 2
+              border_radius: 12
+        "#;
+
+        let options: BadgeOptions =
+            serde_yaml::from_str(yaml).expect("expected badge configuration to deserialize");
+        assert_eq!(options.style, Some(BadgeStyle::Plastic));
+        let widget = options.widget.expect("expected widget options");
+        assert_eq!(widget.columns, Some(2));
+        assert_eq!(widget.alignment, Some(BadgeWidgetAlignment::Center));
+        assert_eq!(widget.border_radius, Some(12));
+    }
+
+    #[test]
+    fn badge_widget_options_reject_invalid_columns() {
+        let yaml = r#"
+            style: flat
+            widget:
+              columns: 6
+        "#;
+
+        let error = serde_yaml::from_str::<BadgeOptions>(yaml).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("columns must be between 1 and 4"));
+    }
+
+    #[test]
+    fn badge_widget_options_reject_invalid_border_radius() {
+        let yaml = r#"
+            widget:
+              border_radius: 64
+        "#;
+
+        let error = serde_yaml::from_str::<BadgeOptions>(yaml).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("border_radius must not exceed 32"));
     }
 }
 

--- a/imir/src/lib.rs
+++ b/imir/src/lib.rs
@@ -5,6 +5,34 @@
 //! driving GitHub Actions matrices. All public APIs are documented with
 //! invariants, error semantics, and minimal examples to facilitate integration
 //! in automation tooling.
+//!
+//! # Examples
+//!
+//! Parse a configuration document that customizes the badge widget and inspect
+//! the resulting normalized descriptor:
+//!
+//! ```
+//! use imir::{parse_targets, BadgeStyle, Error};
+//!
+//! # fn main() -> Result<(), Error> {
+//! let yaml = r#"
+//! targets:
+//!   - owner: octocat
+//!     repo: metrics
+//!     type: open_source
+//!     badge:
+//!       style: flat
+//!       widget:
+//!         columns: 2
+//!         alignment: center
+//! "#;
+//!
+//! let document = parse_targets(yaml)?;
+//! assert_eq!(document.targets[0].badge.style, BadgeStyle::Flat);
+//! assert_eq!(document.targets[0].badge.widget.columns, 2);
+//! # Ok(())
+//! # }
+//! ```
 
 mod config;
 mod error;
@@ -12,8 +40,14 @@ mod normalizer;
 mod open_source;
 mod slug;
 
-pub use config::{TargetConfig, TargetEntry, TargetKind};
+pub use config::{
+    BadgeOptions, BadgeStyle, BadgeWidgetAlignment, BadgeWidgetOptions, TargetConfig, TargetEntry,
+    TargetKind,
+};
 pub use error::{io_error, Error};
-pub use normalizer::{load_targets, parse_targets, RenderTarget, TargetsDocument};
+pub use normalizer::{
+    load_targets, parse_targets, BadgeDescriptor, BadgeWidgetDescriptor, RenderTarget,
+    TargetsDocument,
+};
 pub use open_source::resolve_open_source_repositories;
 pub use slug::SlugStrategy;

--- a/imir/src/normalizer.rs
+++ b/imir/src/normalizer.rs
@@ -11,7 +11,9 @@ use std::{collections::HashSet, fs, path::Path};
 use serde::Serialize;
 
 use crate::{
-    config::{TargetConfig, TargetEntry, TargetKind},
+    config::{
+        BadgeOptions, BadgeStyle, BadgeWidgetAlignment, TargetConfig, TargetEntry, TargetKind,
+    },
     error::{self, Error},
 };
 
@@ -26,6 +28,10 @@ const DEFAULT_EXTENSION: &str = "svg";
 /// Default time zone for renderer execution when none is provided.
 const DEFAULT_TIME_ZONE: &str = "Asia/Ho_Chi_Minh";
 const DEFAULT_CONTRIBUTORS_BRANCH: &str = "main";
+const DEFAULT_BADGE_STYLE: BadgeStyle = BadgeStyle::Classic;
+const DEFAULT_BADGE_COLUMNS: u8 = 1;
+const DEFAULT_BADGE_ALIGNMENT: BadgeWidgetAlignment = BadgeWidgetAlignment::Start;
+const DEFAULT_BADGE_BORDER_RADIUS: u8 = 4;
 
 /// Normalized representation of a metrics target used by automation workflows.
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
@@ -52,6 +58,28 @@ pub struct RenderTarget {
     pub contributors_branch: String,
     /// Flag indicating whether the renderer should include private repositories.
     pub include_private: bool,
+    /// Normalized badge descriptor associated with the target.
+    pub badge: BadgeDescriptor,
+}
+
+/// Normalized badge descriptor emitted alongside render targets.
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct BadgeDescriptor {
+    /// Visual style preset selected for the badge.
+    pub style: BadgeStyle,
+    /// Normalized widget options that control layout.
+    pub widget: BadgeWidgetDescriptor,
+}
+
+/// Normalized widget parameters derived from configuration overrides.
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct BadgeWidgetDescriptor {
+    /// Number of columns used to arrange badge content.
+    pub columns: u8,
+    /// Alignment applied to the badge content.
+    pub alignment: BadgeWidgetAlignment,
+    /// Corner radius applied to the badge in pixels.
+    pub border_radius: u8,
 }
 
 /// Document containing all normalized targets.
@@ -199,6 +227,7 @@ fn normalize_entry(entry: &TargetEntry) -> Result<RenderTarget, Error> {
         .unwrap_or_else(|| DEFAULT_CONTRIBUTORS_BRANCH.to_owned());
 
     let include_private = entry.include_private.unwrap_or(false);
+    let badge = normalize_badge(entry.badge.as_ref())?;
 
     Ok(RenderTarget {
         slug,
@@ -212,7 +241,55 @@ fn normalize_entry(entry: &TargetEntry) -> Result<RenderTarget, Error> {
         display_name,
         contributors_branch,
         include_private,
+        badge,
     })
+}
+
+fn normalize_badge(badge: Option<&BadgeOptions>) -> Result<BadgeDescriptor, Error> {
+    let style = badge
+        .and_then(|options| options.style)
+        .unwrap_or(DEFAULT_BADGE_STYLE);
+    let widget_options = badge.and_then(|options| options.widget.as_ref());
+
+    let columns_value = widget_options
+        .and_then(|widget| widget.columns)
+        .unwrap_or(DEFAULT_BADGE_COLUMNS);
+    let alignment = widget_options
+        .and_then(|widget| widget.alignment)
+        .unwrap_or(DEFAULT_BADGE_ALIGNMENT);
+    let border_radius_value = widget_options
+        .and_then(|widget| widget.border_radius)
+        .unwrap_or(DEFAULT_BADGE_BORDER_RADIUS);
+
+    let columns = validate_badge_columns(columns_value)?;
+    let border_radius = validate_badge_border_radius(border_radius_value)?;
+
+    Ok(BadgeDescriptor {
+        style,
+        widget: BadgeWidgetDescriptor {
+            columns,
+            alignment,
+            border_radius,
+        },
+    })
+}
+
+fn validate_badge_columns(value: u8) -> Result<u8, Error> {
+    if value == 0 || value > 4 {
+        return Err(Error::validation(
+            "badge.widget.columns must be between 1 and 4",
+        ));
+    }
+    Ok(value)
+}
+
+fn validate_badge_border_radius(value: u8) -> Result<u8, Error> {
+    if value > 32 {
+        return Err(Error::validation(
+            "badge.widget.border_radius must not exceed 32",
+        ));
+    }
+    Ok(value)
 }
 
 /// Validates identifier-like fields such as owners or repositories.
@@ -258,7 +335,9 @@ mod tests {
         load_targets, normalize_entry, normalize_identifier, normalize_path_like,
         normalize_targets, parse_targets, Error,
     };
-    use crate::config::{TargetEntry, TargetKind};
+    use crate::config::{
+        BadgeOptions, BadgeStyle, BadgeWidgetAlignment, BadgeWidgetOptions, TargetEntry, TargetKind,
+    };
 
     fn repository_entry() -> TargetEntry {
         TargetEntry {
@@ -273,6 +352,7 @@ mod tests {
             time_zone: None,
             display_name: None,
             include_private: None,
+            badge: None,
         }
     }
 
@@ -288,6 +368,10 @@ mod tests {
         assert_eq!(target.display_name, "metrics");
         assert_eq!(target.contributors_branch, "main");
         assert!(!target.include_private);
+        assert_eq!(target.badge.style, BadgeStyle::Classic);
+        assert_eq!(target.badge.widget.columns, 1);
+        assert_eq!(target.badge.widget.alignment, BadgeWidgetAlignment::Start);
+        assert_eq!(target.badge.widget.border_radius, 4);
     }
 
     #[test]
@@ -317,6 +401,7 @@ mod tests {
             time_zone: None,
             display_name: Some("Infra Metrics Insight Renderer".to_owned()),
             include_private: None,
+            badge: None,
         };
 
         let target = normalize_entry(&entry).expect("expected target to normalize");
@@ -336,6 +421,7 @@ mod tests {
         assert_eq!(target.time_zone, "Asia/Ho_Chi_Minh");
         assert_eq!(target.display_name, "Infra Metrics Insight Renderer");
         assert_eq!(target.contributors_branch, "main");
+        assert_eq!(target.badge.style, BadgeStyle::Classic);
     }
 
     #[test]
@@ -352,6 +438,7 @@ mod tests {
             time_zone: Some("  UTC  ".to_owned()),
             display_name: Some("  Profile Name  ".to_owned()),
             include_private: None,
+            badge: None,
         };
 
         let target = normalize_entry(&entry).expect("expected overrides to be honored");
@@ -362,6 +449,68 @@ mod tests {
         assert_eq!(target.time_zone, "UTC");
         assert_eq!(target.display_name, "Profile Name");
         assert_eq!(target.contributors_branch, "main");
+        assert_eq!(target.badge.style, BadgeStyle::Classic);
+    }
+
+    #[test]
+    fn normalizes_badge_overrides() {
+        let mut entry = repository_entry();
+        entry.badge = Some(BadgeOptions {
+            style: Some(BadgeStyle::FlatSquare),
+            widget: Some(BadgeWidgetOptions {
+                columns: Some(3),
+                alignment: Some(BadgeWidgetAlignment::Center),
+                border_radius: Some(8),
+            }),
+        });
+
+        let target = normalize_entry(&entry).expect("expected badge override to normalize");
+        assert_eq!(target.badge.style, BadgeStyle::FlatSquare);
+        assert_eq!(target.badge.widget.columns, 3);
+        assert_eq!(target.badge.widget.alignment, BadgeWidgetAlignment::Center);
+        assert_eq!(target.badge.widget.border_radius, 8);
+    }
+
+    #[test]
+    fn normalize_entry_rejects_badge_columns_out_of_range() {
+        let mut entry = repository_entry();
+        entry.badge = Some(BadgeOptions {
+            style: None,
+            widget: Some(BadgeWidgetOptions {
+                columns: Some(0),
+                alignment: None,
+                border_radius: None,
+            }),
+        });
+
+        let error = normalize_entry(&entry).expect_err("expected badge validation failure");
+        match error {
+            Error::Validation { message } => {
+                assert_eq!(message, "badge.widget.columns must be between 1 and 4");
+            }
+            other => panic!("expected validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn normalize_entry_rejects_badge_border_radius_out_of_range() {
+        let mut entry = repository_entry();
+        entry.badge = Some(BadgeOptions {
+            style: Some(BadgeStyle::Flat),
+            widget: Some(BadgeWidgetOptions {
+                columns: None,
+                alignment: None,
+                border_radius: Some(64),
+            }),
+        });
+
+        let error = normalize_entry(&entry).expect_err("expected badge validation failure");
+        match error {
+            Error::Validation { message } => {
+                assert_eq!(message, "badge.widget.border_radius must not exceed 32");
+            }
+            other => panic!("expected validation error, got {other:?}"),
+        }
     }
 
     #[test]
@@ -494,7 +643,7 @@ mod tests {
               - owner: octocat
                 repository: metrics
                 type: open_source
-                branch:  feature/metrics 
+                branch:  feature/metrics
         "#;
 
         let document = parse_targets(yaml).expect("expected parse success");
@@ -503,9 +652,56 @@ mod tests {
     }
 
     #[test]
+    fn parse_targets_handles_badge_configuration() {
+        let yaml = r#"
+            targets:
+              - owner: octocat
+                repo: metrics
+                type: open_source
+                badge:
+                  style: for_the_badge
+                  widget:
+                    columns: 2
+                    alignment: end
+                    border_radius: 6
+        "#;
+
+        let document = parse_targets(yaml).expect("expected parse success");
+        assert_eq!(document.targets.len(), 1);
+        let badge = &document.targets[0].badge;
+        assert_eq!(badge.style, BadgeStyle::ForTheBadge);
+        assert_eq!(badge.widget.columns, 2);
+        assert_eq!(badge.widget.alignment, BadgeWidgetAlignment::End);
+        assert_eq!(badge.widget.border_radius, 6);
+    }
+
+    #[test]
     fn parse_targets_propagates_decode_errors() {
         let result = parse_targets("targets: invalid");
         assert!(matches!(result, Err(Error::Parse { .. })));
+    }
+
+    #[test]
+    fn parse_targets_rejects_badge_validation_errors() {
+        let yaml = r#"
+            targets:
+              - owner: octocat
+                repo: metrics
+                type: open_source
+                badge:
+                  widget:
+                    columns: 8
+        "#;
+
+        let error = parse_targets(yaml).expect_err("expected badge validation failure");
+        match error {
+            Error::Parse { ref source } => {
+                assert!(source
+                    .to_string()
+                    .contains("badge.widget.columns must be between 1 and 4"));
+            }
+            other => panic!("expected parse error, got {other:?}"),
+        }
     }
 
     #[test]
@@ -533,6 +729,9 @@ mod tests {
         assert_ne!(base, clone);
         let mut clone = base.clone();
         clone.contributors_branch.push_str("-feature");
+        assert_ne!(base, clone);
+        let mut clone = base.clone();
+        clone.badge.widget.columns = 2;
         assert_ne!(base, clone);
     }
 


### PR DESCRIPTION
## Summary
- add badge customization structures with serde validation to target entries
- normalize badge descriptors with defaults and comprehensive tests
- expose the badge types via the public API and document usage

## Testing
- cargo +nightly fmt --
- cargo +nightly clippy -- -D warnings
- cargo +nightly build --all-targets
- cargo +nightly test --all
- cargo +nightly doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68e06100e034832bb93ab77fb3122c08