### PR TITLE
Limit IMIR release to Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,24 +10,10 @@ permissions:
 
 jobs:
   build:
-    name: Build ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            archive: tar.gz
-            extension: ""
-          - os: macos-14
-            target: aarch64-apple-darwin
-            archive: tar.gz
-            extension: ""
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            archive: zip
-            extension: .exe
+    name: Build x86_64-unknown-linux-gnu
+    runs-on: ubuntu-latest
+    env:
+      ARCHIVE: imir-x86_64-unknown-linux-gnu.tar.gz
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -36,33 +22,21 @@ jobs:
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
 
       - name: Build release binary
-        run: cargo build --release --locked --manifest-path imir/Cargo.toml --target ${{ matrix.target }}
+        run: cargo build --release --locked --manifest-path imir/Cargo.toml
 
-      - name: Package binary (tar.gz)
-        if: ${{ matrix.archive == 'tar.gz' }}
+      - name: Package binary
         run: |
           set -euo pipefail
-          BIN="imir/target/${{ matrix.target }}/release/imir${{ matrix.extension }}"
+          BIN="imir/target/release/imir"
           chmod +x "${BIN}"
-          tar -C "$(dirname "${BIN}")" -czf "imir-${{ matrix.target }}.${{ matrix.archive }}" "$(basename "${BIN}")"
-
-      - name: Package binary (zip)
-        if: ${{ matrix.archive == 'zip' }}
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $bin = "imir/target/${{ matrix.target }}/release/imir${{ matrix.extension }}"
-          $archive = "imir-${{ matrix.target }}.${{ matrix.archive }}"
-          Compress-Archive -Path $bin -DestinationPath $archive -Force
+          tar -C "$(dirname "${BIN}")" -czf "${ARCHIVE}" "$(basename "${BIN}")"
 
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
-          files: imir-${{ matrix.target }}.${{ matrix.archive }}
+          files: ${{ env.ARCHIVE }}
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -270,9 +270,8 @@
   <li>Create an annotated tag (for example, <code>git tag -a v0.1.0</code>) and push it to GitHub.</li>
   <li>Draft a release in the GitHub UI, associate it with the tag, and publish it. Publishing triggers
     <code>.github/workflows/release.yml</code>.</li>
-  <li>The workflow builds the CLI for Linux (<code>x86_64-unknown-linux-gnu</code>), macOS (<code>aarch64-apple-darwin</code>), and
-    Windows (<code>x86_64-pc-windows-msvc</code>), packages the binaries as archives named
-    <code>imir-&lt;target&gt;.tar.gz</code> or <code>imir-&lt;target&gt;.zip</code>, and uploads them to the release assets.</li>
+  <li>The workflow builds the CLI for Linux (<code>x86_64-unknown-linux-gnu</code>), packages the binary as
+    <code>imir-x86_64-unknown-linux-gnu.tar.gz</code>, and uploads it to the release assets.</li>
   <li>Update downstream workflows to download the archive that matches their runner architecture and unpack the <code>imir</code>
     executable into their workspace.</li>
 </ol>

--- a/imir/src/config.rs
+++ b/imir/src/config.rs
@@ -248,12 +248,10 @@ where
     D: serde::Deserializer<'de>,
 {
     let value: Option<u8> = Option::deserialize(deserializer)?;
-    if let Some(columns) = value {
-        if columns == 0 || columns > 4 {
-            return Err(serde::de::Error::custom(
-                "badge.widget.columns must be between 1 and 4",
-            ));
-        }
+    if value.is_some_and(|columns| columns == 0 || columns > 4) {
+        return Err(serde::de::Error::custom(
+            "badge.widget.columns must be between 1 and 4",
+        ));
     }
     Ok(value)
 }
@@ -263,12 +261,10 @@ where
     D: serde::Deserializer<'de>,
 {
     let value: Option<u8> = Option::deserialize(deserializer)?;
-    if let Some(radius) = value {
-        if radius > 32 {
-            return Err(serde::de::Error::custom(
-                "badge.widget.border_radius must not exceed 32",
-            ));
-        }
+    if value.is_some_and(|radius| radius > 32) {
+        return Err(serde::de::Error::custom(
+            "badge.widget.border_radius must not exceed 32",
+        ));
     }
     Ok(value)
 }


### PR DESCRIPTION
## Summary
- limit the release workflow to building the Linux archive and simplify the packaging logic
- document the Linux-only release artifact in the release process section of the README
- tighten optional badge validation by using `Option::is_some_and` to satisfy Clippy

## Testing
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --all-targets --locked
- cargo test --all
- cargo doc --no-deps
- cargo audit -f Cargo.lock
- cargo deny check --config deny.toml


------
https://chatgpt.com/codex/tasks/task_e_68e067ae1218832b93edaff2241a7734