### PR TITLE
Add CLI badge generation workflow

### DIFF
--- a/imir/src/badge.rs
+++ b/imir/src/badge.rs
@@ -1,0 +1,299 @@
+//! Badge asset generation utilities.
+//!
+//! The module materializes lightweight SVG placeholders alongside JSON
+//! manifests that describe the normalized render target. The artifacts are
+//! deterministic so they can be checked into the repository prior to the first
+//! automation run.
+
+use std::{
+    borrow::Cow,
+    fs::{self, File},
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+};
+
+use serde::Serialize;
+
+use crate::{
+    config::TargetKind,
+    error::{self, Error},
+    normalizer::{BadgeDescriptor, RenderTarget},
+};
+
+/// Result of generating badge assets for a render target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BadgeAssets {
+    /// Absolute path to the rendered SVG badge.
+    pub svg_path: PathBuf,
+    /// Absolute path to the JSON manifest describing the badge.
+    pub manifest_path: PathBuf,
+}
+
+/// Generates badge assets for the provided render target inside `output_dir`.
+///
+/// The function creates the directory hierarchy if it does not exist, writes a
+/// deterministic SVG placeholder, and stores a JSON manifest that mirrors the
+/// normalized configuration.
+///
+/// # Errors
+///
+/// Returns [`Error::BadgeIo`](Error::BadgeIo) when directories or files cannot
+/// be created and [`Error::Serialize`](Error::Serialize) if the manifest cannot
+/// be encoded.
+pub fn generate_badge_assets(
+    target: &RenderTarget,
+    output_dir: &Path,
+) -> Result<BadgeAssets, Error> {
+    fs::create_dir_all(output_dir).map_err(|source| error::badge_io_error(output_dir, source))?;
+
+    let svg_path = output_dir.join(format!("{}.svg", target.slug,));
+    let manifest_path = output_dir.join(format!("{}.json", target.slug,));
+
+    write_svg(&svg_path, target)?;
+    write_manifest(&manifest_path, target, &svg_path)?;
+
+    Ok(BadgeAssets {
+        svg_path,
+        manifest_path,
+    })
+}
+
+fn write_svg(path: &Path, target: &RenderTarget) -> Result<(), Error> {
+    let contents = build_svg_content(target);
+    let file = File::create(path).map_err(|source| error::badge_io_error(path, source))?;
+    let mut writer = BufWriter::new(file);
+    writer
+        .write_all(contents.as_bytes())
+        .map_err(|source| error::badge_io_error(path, source))?;
+    writer
+        .flush()
+        .map_err(|source| error::badge_io_error(path, source))
+}
+
+fn write_manifest(path: &Path, target: &RenderTarget, svg_path: &Path) -> Result<(), Error> {
+    let manifest = BadgeManifest {
+        slug: &target.slug,
+        owner: &target.owner,
+        repository: target.repository.as_deref(),
+        kind: target.kind,
+        display_name: &target.display_name,
+        target_path: &target.target_path,
+        svg_artifact: path_to_string(svg_path),
+        badge: &target.badge,
+    };
+
+    let file = File::create(path).map_err(|source| error::badge_io_error(path, source))?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(&mut writer, &manifest)?;
+    writer
+        .write_all(b"\n")
+        .map_err(|source| error::badge_io_error(path, source))?;
+    writer
+        .flush()
+        .map_err(|source| error::badge_io_error(path, source))
+}
+
+fn path_to_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn build_svg_content(target: &RenderTarget) -> String {
+    let mut buffer = String::with_capacity(256);
+    let background = badge_background(target.kind);
+    let label = badge_label(target);
+    let escaped_label = escape_xml(&label);
+    let escaped_display = escape_xml(&target.display_name);
+
+    use std::fmt::Write as _;
+
+    let _ = writeln!(
+        buffer,
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\" role=\"img\" aria-label=\"{}\" width=\"440\" height=\"140\" viewBox=\"0 0 440 140\">",
+        escaped_display,
+    );
+    let _ = writeln!(
+        buffer,
+        "  <defs>\n    <linearGradient id=\"imir-badge\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"1\">\n      <stop offset=\"0%\" stop-color=\"{}\" stop-opacity=\"0.92\"/>\n      <stop offset=\"100%\" stop-color=\"{}\" stop-opacity=\"1\"/>\n    </linearGradient>\n  </defs>",
+        background.primary, background.secondary,
+    );
+    buffer.push_str("  <rect x=\"8\" y=\"8\" width=\"424\" height=\"124\" rx=\"16\" fill=\"url(#imir-badge)\"/>");
+    let _ = writeln!(
+        buffer,
+        "\n  <text x=\"220\" y=\"60\" text-anchor=\"middle\" font-family=\"'Segoe UI', 'SF Pro Display', sans-serif\" font-size=\"22\" fill=\"#ffffff\">{}</text>",
+        escaped_label,
+    );
+    let _ = writeln!(
+        buffer,
+        "  <text x=\"220\" y=\"98\" text-anchor=\"middle\" font-family=\"'Segoe UI', 'SF Pro Display', sans-serif\" font-size=\"18\" fill=\"#f6f8fa\">{}</text>",
+        escaped_display,
+    );
+    buffer.push_str("</svg>\n");
+
+    buffer
+}
+
+fn badge_label(target: &RenderTarget) -> Cow<'_, str> {
+    match target.repository.as_deref() {
+        Some(repository) => {
+            let mut owned = String::with_capacity(target.owner.len() + repository.len() + 1);
+            owned.push_str(target.owner.as_str());
+            owned.push('/');
+            owned.push_str(repository);
+            Cow::Owned(owned)
+        }
+        None => Cow::Borrowed(target.owner.as_str()),
+    }
+}
+
+fn escape_xml(value: &str) -> Cow<'_, str> {
+    if value
+        .chars()
+        .any(|character| matches!(character, '&' | '<' | '>' | '\"' | '\''))
+    {
+        let mut escaped = String::with_capacity(value.len());
+        for character in value.chars() {
+            match character {
+                '&' => escaped.push_str("&amp;"),
+                '<' => escaped.push_str("&lt;"),
+                '>' => escaped.push_str("&gt;"),
+                '\"' => escaped.push_str("&quot;"),
+                '\'' => escaped.push_str("&apos;"),
+                other => escaped.push(other),
+            }
+        }
+        Cow::Owned(escaped)
+    } else {
+        Cow::Borrowed(value)
+    }
+}
+
+struct BadgeGradient {
+    primary: &'static str,
+    secondary: &'static str,
+}
+
+fn badge_background(kind: TargetKind) -> BadgeGradient {
+    match kind {
+        TargetKind::Profile => BadgeGradient {
+            primary: "#6f42c1",
+            secondary: "#8648d1",
+        },
+        TargetKind::OpenSource => BadgeGradient {
+            primary: "#1f883d",
+            secondary: "#2ea043",
+        },
+        TargetKind::PrivateProject => BadgeGradient {
+            primary: "#0a3069",
+            secondary: "#1b4b91",
+        },
+    }
+}
+
+#[derive(Serialize)]
+struct BadgeManifest<'a> {
+    slug: &'a str,
+    owner: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repository: Option<&'a str>,
+    kind: TargetKind,
+    display_name: &'a str,
+    target_path: &'a str,
+    svg_artifact: String,
+    badge: &'a BadgeDescriptor,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::{
+        config::{BadgeStyle, BadgeWidgetAlignment},
+        normalizer::BadgeWidgetDescriptor,
+    };
+
+    fn sample_target(kind: TargetKind) -> RenderTarget {
+        RenderTarget {
+            slug: "sample".to_owned(),
+            owner: "octocat".to_owned(),
+            repository: Some("example".to_owned()),
+            kind,
+            branch_name: "branch".to_owned(),
+            target_path: "metrics/sample.svg".to_owned(),
+            temp_artifact: "tmp/sample.svg".to_owned(),
+            time_zone: "UTC".to_owned(),
+            display_name: "Example Dashboard".to_owned(),
+            contributors_branch: "main".to_owned(),
+            include_private: false,
+            badge: BadgeDescriptor {
+                style: BadgeStyle::Classic,
+                widget: BadgeWidgetDescriptor {
+                    columns: 2,
+                    alignment: BadgeWidgetAlignment::Center,
+                    border_radius: 6,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn generate_badge_assets_writes_svg_and_manifest() {
+        let target = sample_target(TargetKind::OpenSource);
+        let directory = tempdir().expect("failed to create temp dir");
+        let output_dir = directory.path().join("out");
+
+        let assets = generate_badge_assets(&target, &output_dir)
+            .expect("expected badge generation to succeed");
+
+        assert!(assets.svg_path.exists());
+        assert!(assets.manifest_path.exists());
+
+        let svg = fs::read_to_string(&assets.svg_path).expect("expected svg to be readable");
+        assert!(svg.contains("octocat/example"));
+        assert!(svg.contains("Example Dashboard"));
+        assert!(svg.contains("#2ea043"));
+
+        let manifest =
+            fs::read_to_string(&assets.manifest_path).expect("expected manifest to be readable");
+        let value: Value =
+            serde_json::from_str(&manifest).expect("expected manifest to be valid JSON");
+        assert_eq!(value["slug"], "sample");
+        assert_eq!(value["owner"], "octocat");
+        assert_eq!(value["repository"], "example");
+        assert_eq!(value["kind"], "open_source");
+        assert_eq!(value["target_path"], "metrics/sample.svg");
+        assert!(value["svg_artifact"].as_str().is_some());
+    }
+
+    #[test]
+    fn generate_badge_assets_propagates_directory_errors() {
+        let target = sample_target(TargetKind::Profile);
+        let directory = tempdir().expect("failed to create temp dir");
+        let file_path = directory.path().join("blocked");
+        File::create(&file_path).expect("failed to create placeholder file");
+
+        let error = generate_badge_assets(&target, &file_path).expect_err("expected io failure");
+
+        match error {
+            Error::BadgeIo { path, .. } => {
+                assert_eq!(path, file_path);
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn svg_renderer_escapes_dynamic_content() {
+        let mut target = sample_target(TargetKind::PrivateProject);
+        target.display_name = "ACME & <Partners>".to_owned();
+        target.repository = None;
+        target.owner = "Org > Team".to_owned();
+
+        let svg = build_svg_content(&target);
+        assert!(svg.contains("Org &gt; Team"));
+        assert!(svg.contains("ACME &amp; &lt;Partners&gt;"));
+    }
+}

--- a/imir/src/error.rs
+++ b/imir/src/error.rs
@@ -13,51 +13,53 @@ use std::path::{Path, PathBuf};
 /// accidental exposure of sensitive data. Instances are typically constructed
 /// through the [`io_error`] helper or by converting from serde error types via
 /// the provided `From` implementations.
-#[derive(Debug, masterror::Error,)]
-pub enum Error
-{
+#[derive(Debug, masterror::Error)]
+pub enum Error {
     /// Wraps I/O errors that occur while reading configuration files.
     #[error("failed to read configuration from {path:?}: {source}")]
-    Io
-    {
+    Io {
         /// Location of the configuration file.
-        path:   PathBuf,
+        path: PathBuf,
         /// Underlying I/O error.
         source: std::io::Error,
     },
     /// Wraps YAML decoding errors.
     #[error("failed to parse configuration: {source}")]
-    Parse
-    {
+    Parse {
         /// Source decoding error from serde_yaml.
         source: serde_yaml::Error,
     },
     /// Returned when the configuration violates invariants.
     #[error("invalid configuration: {message}")]
-    Validation
-    {
+    Validation {
         /// Human readable message describing the validation problem.
         message: String,
     },
     /// Wraps serialization errors when writing normalized output.
     #[error("failed to serialize targets: {source}")]
-    Serialize
-    {
+    Serialize {
         /// Underlying serialization error.
         source: serde_json::Error,
     },
+    /// Wraps I/O errors that occur while writing badge artifacts.
+    #[error("failed to write badge artifact at {path:?}: {source}")]
+    BadgeIo {
+        /// Location of the artifact being produced.
+        path: PathBuf,
+        /// Underlying I/O error reported by the operating system.
+        source: std::io::Error,
+    },
 }
 
-impl Error
-{
+impl Error {
     /// Constructs a validation error from the provided displayable value.
     ///
     /// # Parameters
     ///
     /// * `message` - Human-readable description of the validation failure.
-    pub fn validation<M,>(message: M,) -> Self
+    pub fn validation<M>(message: M) -> Self
     where
-        M: Into<String,>,
+        M: Into<String>,
     {
         Self::Validation {
             message: message.into(),
@@ -69,29 +71,20 @@ impl Error
     /// This method is primarily intended for CLI contexts where the variant
     /// name does not add value to end users. The returned string matches the
     /// [`std::fmt::Display`] implementation.
-    pub fn to_display_string(&self,) -> String
-    {
+    pub fn to_display_string(&self) -> String {
         format!("{self}")
     }
 }
 
-impl From<serde_yaml::Error,> for Error
-{
-    fn from(source: serde_yaml::Error,) -> Self
-    {
-        Self::Parse {
-            source,
-        }
+impl From<serde_yaml::Error> for Error {
+    fn from(source: serde_yaml::Error) -> Self {
+        Self::Parse { source }
     }
 }
 
-impl From<serde_json::Error,> for Error
-{
-    fn from(source: serde_json::Error,) -> Self
-    {
-        Self::Serialize {
-            source,
-        }
+impl From<serde_json::Error> for Error {
+    fn from(source: serde_json::Error) -> Self {
+        Self::Serialize { source }
     }
 }
 
@@ -101,27 +94,35 @@ impl From<serde_json::Error,> for Error
 ///
 /// * `path` - Location of the configuration file that triggered the error.
 /// * `source` - I/O error reported by the operating system.
-pub fn io_error(path: &Path, source: std::io::Error,) -> Error
-{
+pub fn io_error(path: &Path, source: std::io::Error) -> Error {
     Error::Io {
         path: path.to_path_buf(),
         source,
     }
 }
 
+/// Creates an [`Error::BadgeIo`] variant capturing the failing path and source.
+///
+/// # Parameters
+///
+/// * `path` - Location of the badge artifact that triggered the error.
+/// * `source` - I/O error reported by the operating system.
+pub fn badge_io_error(path: &Path, source: std::io::Error) -> Error {
+    Error::BadgeIo {
+        path: path.to_path_buf(),
+        source,
+    }
+}
+
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use super::Error;
 
     #[test]
-    fn validation_constructor_populates_message()
-    {
-        let error = Error::validation("something went wrong",);
+    fn validation_constructor_populates_message() {
+        let error = Error::validation("something went wrong");
         match error {
-            Error::Validation {
-                ref message,
-            } => {
+            Error::Validation { ref message } => {
                 assert_eq!(message, "something went wrong");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -129,18 +130,16 @@ mod tests
     }
 
     #[test]
-    fn to_display_string_matches_display()
-    {
-        let error = Error::validation("display me",);
+    fn to_display_string_matches_display() {
+        let error = Error::validation("display me");
         assert_eq!(error.to_string(), error.to_display_string());
     }
 
     #[test]
-    fn io_error_helper_wraps_path_and_source()
-    {
-        let path = std::path::Path::new("/tmp/example.yaml",);
-        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "missing",);
-        let error = super::io_error(path, io_error,);
+    fn io_error_helper_wraps_path_and_source() {
+        let path = std::path::Path::new("/tmp/example.yaml");
+        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let error = super::io_error(path, io_error);
 
         match error {
             Error::Io {
@@ -155,18 +154,34 @@ mod tests
     }
 
     #[test]
-    fn serde_yaml_conversion_maps_to_parse_variant()
-    {
-        let error = serde_yaml::from_str::<usize,>("not-a-number",).unwrap_err();
+    fn serde_yaml_conversion_maps_to_parse_variant() {
+        let error = serde_yaml::from_str::<usize>("not-a-number").unwrap_err();
         let mapped: Error = error.into();
         assert!(matches!(mapped, Error::Parse { .. }));
     }
 
     #[test]
-    fn serde_json_conversion_maps_to_serialize_variant()
-    {
-        let invalid = serde_json::from_str::<serde_json::Value,>("not-json",).unwrap_err();
+    fn serde_json_conversion_maps_to_serialize_variant() {
+        let invalid = serde_json::from_str::<serde_json::Value>("not-json").unwrap_err();
         let mapped: Error = invalid.into();
         assert!(matches!(mapped, Error::Serialize { .. }));
+    }
+
+    #[test]
+    fn badge_io_error_helper_wraps_path_and_source() {
+        let path = std::path::Path::new("/tmp/badge.svg");
+        let io_error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let error = super::badge_io_error(path, io_error);
+
+        match error {
+            Error::BadgeIo {
+                path: ref stored_path,
+                ref source,
+            } => {
+                assert_eq!(stored_path, path);
+                assert_eq!(source.kind(), std::io::ErrorKind::PermissionDenied);
+            }
+            other => panic!("expected badge io error, got {other:?}"),
+        }
     }
 }

--- a/imir/src/lib.rs
+++ b/imir/src/lib.rs
@@ -34,20 +34,22 @@
 //! # }
 //! ```
 
+mod badge;
 mod config;
 mod error;
 mod normalizer;
 mod open_source;
 mod slug;
 
+pub use badge::{BadgeAssets, generate_badge_assets};
 pub use config::{
     BadgeOptions, BadgeStyle, BadgeWidgetAlignment, BadgeWidgetOptions, TargetConfig, TargetEntry,
     TargetKind,
 };
-pub use error::{io_error, Error};
+pub use error::{Error, io_error};
 pub use normalizer::{
-    load_targets, parse_targets, BadgeDescriptor, BadgeWidgetDescriptor, RenderTarget,
-    TargetsDocument,
+    BadgeDescriptor, BadgeWidgetDescriptor, RenderTarget, TargetsDocument, load_targets,
+    parse_targets,
 };
 pub use open_source::resolve_open_source_repositories;
 pub use slug::SlugStrategy;

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -10,37 +10,38 @@ use std::{
 };
 
 use clap::{ArgAction, Args, Parser, Subcommand};
-use imir::{load_targets, resolve_open_source_repositories, Error, TargetsDocument};
+use imir::{
+    Error, TargetsDocument, generate_badge_assets, load_targets, resolve_open_source_repositories,
+};
 
 /// Command line interface for generating normalized metrics target definitions.
-#[derive(Debug, Parser,)]
+#[derive(Debug, Parser)]
 #[command(name = "imir", version, about = "Normalize metrics renderer targets")]
 /// Top-level CLI options parsed from user input.
-struct Cli
-{
+struct Cli {
     #[command(subcommand)]
-    command: Option<Command,>,
+    command: Option<Command>,
 
     /// Legacy argument support for the default targets command.
     #[command(flatten)]
     legacy: LegacyTargetsArgs,
 }
 
-#[derive(Debug, Subcommand,)]
+#[derive(Debug, Subcommand)]
 /// Supported commands exposed by the CLI.
-enum Command
-{
+enum Command {
     /// Normalize targets from a YAML configuration file.
-    Targets(TargetsArgs,),
+    Targets(TargetsArgs),
     /// Resolve repository inputs for the open-source render workflow.
     #[command(name = "open-source")]
-    OpenSource(OpenSourceArgs,),
+    OpenSource(OpenSourceArgs),
+    /// Generate badge assets for a normalized target.
+    Badge(BadgeArgs),
 }
 
-#[derive(Debug, Args,)]
+#[derive(Debug, Args)]
 /// Arguments accepted by the `targets` subcommand.
-struct TargetsArgs
-{
+struct TargetsArgs {
     /// Path to the YAML configuration file describing metrics targets.
     #[arg(long = "config", value_name = "PATH")]
     config: PathBuf,
@@ -51,32 +52,56 @@ struct TargetsArgs
 }
 
 /// Arguments accepted when the CLI is invoked without a subcommand.
-#[derive(Debug, Args, Default,)]
-struct LegacyTargetsArgs
-{
+#[derive(Debug, Args, Default)]
+struct LegacyTargetsArgs {
     /// Path to the YAML configuration file describing metrics targets.
     #[arg(long = "config", value_name = "PATH")]
-    config: Option<PathBuf,>,
+    config: Option<PathBuf>,
 
     /// Output formatted JSON for easier inspection.
     #[arg(long = "pretty", action = ArgAction::SetTrue)]
     pretty: bool,
 }
 
-#[derive(Debug, Args,)]
-struct OpenSourceArgs
-{
+#[derive(Debug, Args)]
+struct OpenSourceArgs {
     /// Raw repositories JSON provided by the workflow input.
     #[arg(long = "input", value_name = "JSON")]
-    input: Option<String,>,
+    input: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct BadgeArgs {
+    #[command(subcommand)]
+    command: BadgeCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum BadgeCommand {
+    /// Materialize deterministic badge assets for a target slug.
+    Generate(BadgeGenerateArgs),
+}
+
+#[derive(Debug, Args)]
+struct BadgeGenerateArgs {
+    /// Path to the YAML configuration file describing metrics targets.
+    #[arg(long = "config", value_name = "PATH")]
+    config: PathBuf,
+
+    /// Slug identifying the target to generate badge assets for.
+    #[arg(long = "target", value_name = "SLUG")]
+    target: String,
+
+    /// Directory that will receive the SVG and manifest artifacts.
+    #[arg(long = "output", value_name = "DIR", default_value = "metrics")]
+    output: PathBuf,
 }
 
 /// Entry point that reports errors and sets the appropriate exit status.
-fn main()
-{
-    if let Err(error,) = run() {
+fn main() {
+    if let Err(error) = run() {
         eprintln!("{}", error.to_display_string());
-        process::exit(1,);
+        process::exit(1);
     }
 }
 
@@ -85,45 +110,42 @@ fn main()
 /// # Errors
 ///
 /// Propagates errors originating from configuration loading and normalization.
-fn run() -> Result<(), Error,>
-{
+fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Command::Targets(args,),) => run_targets(args,),
-        Some(Command::OpenSource(args,),) => run_open_source(args,),
-        None => run_legacy_targets(&cli.legacy,),
+        Some(Command::Targets(args)) => run_targets(args),
+        Some(Command::OpenSource(args)) => run_open_source(args),
+        Some(Command::Badge(args)) => run_badge(args),
+        None => run_legacy_targets(&cli.legacy),
     }
 }
 
-fn run_targets(args: TargetsArgs,) -> Result<(), Error,>
-{
-    run_targets_from_path(&args.config, args.pretty,)
+fn run_targets(args: TargetsArgs) -> Result<(), Error> {
+    run_targets_from_path(&args.config, args.pretty)
 }
 
-fn run_targets_from_path(path: &Path, pretty: bool,) -> Result<(), Error,>
-{
-    let document = load_targets(path,)?;
+fn run_targets_from_path(path: &Path, pretty: bool) -> Result<(), Error> {
+    let document = load_targets(path)?;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    write_targets_document(&mut handle, &document, pretty,)
+    write_targets_document(&mut handle, &document, pretty)
 }
 
-fn write_targets_document<W: io::Write,>(
+fn write_targets_document<W: io::Write>(
     writer: &mut W,
     document: &TargetsDocument,
     pretty: bool,
-) -> Result<(), Error,>
-{
+) -> Result<(), Error> {
     if pretty {
-        serde_json::to_writer_pretty(writer, document,)?;
+        serde_json::to_writer_pretty(writer, document)?;
     } else {
-        serde_json::to_writer(writer, document,)?;
+        serde_json::to_writer(writer, document)?;
     }
 
-    Ok((),)
+    Ok(())
 }
 
 /// Handles the `open-source` subcommand by normalizing repository inputs.
@@ -132,44 +154,67 @@ fn write_targets_document<W: io::Write,>(
 ///
 /// Returns an [`Error`] when repository inputs are invalid or serialization
 /// fails.
-fn run_open_source(args: OpenSourceArgs,) -> Result<(), Error,>
-{
-    let trimmed = args.input.as_deref().map(str::trim,).filter(|value| !value.is_empty(),);
+fn run_open_source(args: OpenSourceArgs) -> Result<(), Error> {
+    let trimmed = args
+        .input
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
 
-    let repositories = resolve_open_source_repositories(trimmed,)?;
+    let repositories = resolve_open_source_repositories(trimmed)?;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    serde_json::to_writer(&mut handle, &repositories,)?;
+    serde_json::to_writer(&mut handle, &repositories)?;
 
-    Ok((),)
+    Ok(())
 }
 
-fn run_legacy_targets(args: &LegacyTargetsArgs,) -> Result<(), Error,>
-{
+fn run_legacy_targets(args: &LegacyTargetsArgs) -> Result<(), Error> {
     let config = args
         .config
         .as_deref()
-        .ok_or_else(|| Error::validation("missing required --config <PATH> argument",),)?;
+        .ok_or_else(|| Error::validation("missing required --config <PATH> argument"))?;
 
-    run_targets_from_path(config, args.pretty,)
+    run_targets_from_path(config, args.pretty)
+}
+
+fn run_badge(args: BadgeArgs) -> Result<(), Error> {
+    match args.command {
+        BadgeCommand::Generate(arguments) => run_badge_generate(arguments),
+    }
+}
+
+fn run_badge_generate(args: BadgeGenerateArgs) -> Result<(), Error> {
+    let document = load_targets(&args.config)?;
+    let slug = args.target.as_str();
+    let target = document
+        .targets
+        .iter()
+        .find(|candidate| candidate.slug.as_str() == slug)
+        .ok_or_else(|| Error::validation(format!("target '{slug}' was not found",)))?;
+
+    generate_badge_assets(target, &args.output)?;
+
+    Ok(())
 }
 
 #[cfg(test)]
-mod tests
-{
-    use std::{io::Cursor, path::Path};
+mod tests {
+    use std::{fs, io::Cursor, path::Path};
 
     use clap::Parser;
     use imir::TargetsDocument;
+    use tempfile::tempdir;
 
-    use super::{run_legacy_targets, write_targets_document, Cli, Command, LegacyTargetsArgs};
+    use super::{
+        Cli, Command, LegacyTargetsArgs, run_badge, run_legacy_targets, write_targets_document,
+    };
 
     #[test]
-    fn cli_accepts_legacy_targets_invocation()
-    {
-        let cli = Cli::try_parse_from([env!("CARGO_PKG_NAME"), "--config", "config.yaml",],)
-            .expect("failed to parse CLI",);
+    fn cli_accepts_legacy_targets_invocation() {
+        let cli = Cli::try_parse_from([env!("CARGO_PKG_NAME"), "--config", "config.yaml"])
+            .expect("failed to parse CLI");
 
         assert!(cli.command.is_none());
         assert_eq!(cli.legacy.config.as_deref(), Some(Path::new("config.yaml")));
@@ -177,15 +222,12 @@ mod tests
     }
 
     #[test]
-    fn legacy_targets_require_config_path()
-    {
+    fn legacy_targets_require_config_path() {
         let args = LegacyTargetsArgs::default();
-        let error = run_legacy_targets(&args,).expect_err("expected validation error",);
+        let error = run_legacy_targets(&args).expect_err("expected validation error");
 
         match error {
-            imir::Error::Validation {
-                message,
-            } => {
+            imir::Error::Validation { message } => {
                 assert_eq!(message, "missing required --config <PATH> argument");
             }
             other => panic!("unexpected error variant: {other:?}"),
@@ -193,19 +235,18 @@ mod tests
     }
 
     #[test]
-    fn targets_subcommand_pretty_flag_uses_pretty_writer()
-    {
+    fn targets_subcommand_pretty_flag_uses_pretty_writer() {
         let cli = Cli::try_parse_from([
             env!("CARGO_PKG_NAME"),
             "targets",
             "--config",
             "config.yaml",
             "--pretty",
-        ],)
-        .expect("failed to parse CLI",);
+        ])
+        .expect("failed to parse CLI");
 
-        let args = match cli.command.expect("missing targets command",) {
-            Command::Targets(args,) => args,
+        let args = match cli.command.expect("missing targets command") {
+            Command::Targets(args) => args,
             _ => panic!("unexpected command variant"),
         };
         assert!(args.pretty);
@@ -213,19 +254,18 @@ mod tests
         let document = TargetsDocument {
             targets: Vec::new(),
         };
-        let mut buffer = Cursor::new(Vec::new(),);
-        write_targets_document(&mut buffer, &document, args.pretty,)
-            .expect("failed to serialize targets",);
+        let mut buffer = Cursor::new(Vec::new());
+        write_targets_document(&mut buffer, &document, args.pretty)
+            .expect("failed to serialize targets");
 
-        let output = String::from_utf8(buffer.into_inner(),).expect("invalid UTF-8",);
+        let output = String::from_utf8(buffer.into_inner()).expect("invalid UTF-8");
         assert_eq!(output, "{\n  \"targets\": []\n}");
     }
 
     #[test]
-    fn legacy_invocation_without_pretty_uses_compact_writer()
-    {
-        let cli = Cli::try_parse_from([env!("CARGO_PKG_NAME"), "--config", "config.yaml",],)
-            .expect("failed to parse CLI",);
+    fn legacy_invocation_without_pretty_uses_compact_writer() {
+        let cli = Cli::try_parse_from([env!("CARGO_PKG_NAME"), "--config", "config.yaml"])
+            .expect("failed to parse CLI");
 
         assert!(cli.command.is_none());
         assert!(!cli.legacy.pretty);
@@ -233,11 +273,89 @@ mod tests
         let document = TargetsDocument {
             targets: Vec::new(),
         };
-        let mut buffer = Cursor::new(Vec::new(),);
-        write_targets_document(&mut buffer, &document, cli.legacy.pretty,)
-            .expect("failed to serialize targets",);
+        let mut buffer = Cursor::new(Vec::new());
+        write_targets_document(&mut buffer, &document, cli.legacy.pretty)
+            .expect("failed to serialize targets");
 
-        let output = String::from_utf8(buffer.into_inner(),).expect("invalid UTF-8",);
+        let output = String::from_utf8(buffer.into_inner()).expect("invalid UTF-8");
         assert_eq!(output, "{\"targets\":[]}");
+    }
+
+    #[test]
+    fn badge_generate_writes_assets() {
+        let temp = tempdir().expect("failed to create tempdir");
+        let config_path = temp.path().join("targets.yaml");
+        let output_dir = temp.path().join("artifacts");
+        let yaml = r#"
+targets:
+  - owner: example
+    repository: repo
+    type: open_source
+    slug: example-repo
+"#;
+        fs::write(&config_path, yaml).expect("failed to write config");
+
+        let cli = Cli::try_parse_from([
+            env!("CARGO_PKG_NAME"),
+            "badge",
+            "generate",
+            "--config",
+            config_path.to_str().expect("utf8"),
+            "--target",
+            "example-repo",
+            "--output",
+            output_dir.to_str().expect("utf8"),
+        ])
+        .expect("failed to parse badge command");
+
+        let args = match cli.command.expect("missing command") {
+            Command::Badge(arguments) => arguments,
+            other => panic!("unexpected command variant: {other:?}"),
+        };
+
+        run_badge(args).expect("badge generation failed");
+
+        let svg_path = output_dir.join("example-repo.svg");
+        let manifest_path = output_dir.join("example-repo.json");
+        assert!(svg_path.exists());
+        assert!(manifest_path.exists());
+    }
+
+    #[test]
+    fn badge_generate_reports_missing_target() {
+        let temp = tempdir().expect("failed to create tempdir");
+        let config_path = temp.path().join("targets.yaml");
+        let yaml = r#"
+targets:
+  - owner: example
+    repository: repo
+    type: open_source
+    slug: existing
+"#;
+        fs::write(&config_path, yaml).expect("failed to write config");
+
+        let cli = Cli::try_parse_from([
+            env!("CARGO_PKG_NAME"),
+            "badge",
+            "generate",
+            "--config",
+            config_path.to_str().expect("utf8"),
+            "--target",
+            "missing",
+        ])
+        .expect("failed to parse badge command");
+
+        let args = match cli.command.expect("missing command") {
+            Command::Badge(arguments) => arguments,
+            other => panic!("unexpected command variant: {other:?}"),
+        };
+
+        let error = run_badge(args).expect_err("expected missing target error");
+        match error {
+            imir::Error::Validation { message } => {
+                assert!(message.contains("target 'missing' was not found"));
+            }
+            other => panic!("unexpected error variant: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a badge asset generator module that produces SVG and JSON outputs and export it from the library
- extend the CLI with a `badge generate` command that loads targets, selects a slug, and writes the assets
- cover the new module and CLI flows with unit tests

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 clippy -- -D warnings
- cargo +1.90.0 build --all-targets
- cargo +1.90.0 test --all
- cargo +1.90.0 doc --no-deps
- cargo audit
- cargo deny check

------
https://chatgpt.com/codex/tasks/task_e_68e0776cd044832baad5b78a0738c7b3