### PR TITLE
Enable private insights for RAprogramm profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@
   <li><code>contributors_branch</code> – specify the repository branch analyzed by the contributors plugin.</li>
   <li><code>time_zone</code> – customize the time zone passed to the renderer.</li>
   <li><code>slug</code> – override the derived slug used for filenames and workflow dispatch names.</li>
-  <li><code>include_private</code> – set to <code>true</code> to include private repositories and secret achievements for the target.</li>
+  <li><code>include_private</code> – set to <code>true</code> to include private repositories and secret achievements for the target. Profile cards owned by <code>RAprogramm</code> enable this flag by default so the dashboard reflects private activity without additional configuration.</li>
 </ul>
 
 <p>


### PR DESCRIPTION
## Summary
- default the `include_private` flag to true for RAprogramm profile targets during normalization
- add regression tests covering the new default handling and helper used by the normalizer
- document the behavior change in the configuration README section

## Testing
- cargo +nightly fmt --manifest-path imir/Cargo.toml
- cargo +1.90.0 clippy --manifest-path imir/Cargo.toml -- -D warnings
- cargo +1.90.0 build --manifest-path imir/Cargo.toml --all-targets
- cargo +1.90.0 test --manifest-path imir/Cargo.toml --all
- cargo +1.90.0 doc --manifest-path imir/Cargo.toml --no-deps
- (cd imir && cargo audit)
- (cd imir && cargo deny check --config ../deny.toml)

------
https://chatgpt.com/codex/tasks/task_e_68e07d4a284c832b80fa98ef9d399d18