### PR TITLE
Enhance open-source workflow with contributor descriptors

### DIFF
--- a/.github/workflows/render-open-source.yml
+++ b/.github/workflows/render-open-source.yml
@@ -5,19 +5,21 @@ on:
     inputs:
       repositories:
         description: >-
-          JSON array with repository names that should be refreshed.
-          Defaults to ["masterror", "telegram-webapp-sdk"].
+          JSON array with repository descriptors that should be refreshed.
+          Each entry may be a repository string or an object with
+          `repository` and optional `contributors_branch`.
         required: false
-        default: '["masterror", "telegram-webapp-sdk"]'
+        default: '[{"repository":"masterror"}, {"repository":"telegram-webapp-sdk"}]'
   workflow_call:
     inputs:
       repositories:
         description: >-
-          JSON array with repository names that should be refreshed.
-          Defaults to ["masterror", "telegram-webapp-sdk"].
+          JSON array with repository descriptors that should be refreshed.
+          Each entry may be a repository string or an object with
+          `repository` and optional `contributors_branch`.
         required: false
         type: string
-        default: '["masterror", "telegram-webapp-sdk"]'
+        default: '[{"repository":"masterror"}, {"repository":"telegram-webapp-sdk"}]'
     secrets:
       CLASSIC:
         required: true
@@ -26,7 +28,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      repositories: ${{ steps.resolve.outputs.repositories }}
+      targets: ${{ steps.resolve.outputs.targets }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -46,8 +48,8 @@ jobs:
         run: |
           set -euo pipefail
           RAW="${RAW_INPUT:-}"
-          REPOSITORIES=$(cargo run --manifest-path imir/Cargo.toml --quiet --locked -- open-source --input "${RAW}")
-          printf 'repositories=%s\n' "${REPOSITORIES}" >> "${GITHUB_OUTPUT}"
+          TARGETS=$(cargo run --manifest-path imir/Cargo.toml --quiet --locked -- open-source --input "${RAW}")
+          printf 'targets=%s\n' "${TARGETS}" >> "${GITHUB_OUTPUT}"
 
   render:
     needs: prepare
@@ -55,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        repository: ${{ fromJSON(needs.prepare.outputs.repositories) }}
+        target: ${{ fromJSON(needs.prepare.outputs.targets) }}
     permissions:
       contents: write
       pull-requests: write
@@ -63,13 +65,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Render metrics for ${{ matrix.repository }}
+      - name: Render metrics for ${{ matrix.target.repository }}
         uses: ./.github/actions/render-repository
         with:
           classic_token: ${{ secrets.CLASSIC }}
           target_owner: RAprogramm
-          target_repo: ${{ matrix.repository }}
-          branch_name: ${{ format('ci/metrics-refresh-{0}', matrix.repository) }}
-          contributors_branch: main
-          target_path: ${{ format('metrics/{0}.svg', matrix.repository) }}
-          temp_artifact: ${{ format('.metrics-tmp/{0}.svg', matrix.repository) }}
+          target_repo: ${{ matrix.target.repository }}
+          branch_name: ${{ format('ci/metrics-refresh-{0}', matrix.target.repository) }}
+          contributors_branch: ${{ matrix.target.contributors_branch }}
+          target_path: ${{ format('metrics/{0}.svg', matrix.target.repository) }}
+          temp_artifact: ${{ format('.metrics-tmp/{0}.svg', matrix.target.repository) }}

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@
   open_source:
     uses: RAprogramm/infra-metrics-insight-renderer/.github/workflows/render-open-source.yml@main
     with:
-      repositories: '["masterror", "telegram-webapp-sdk"]'
+      repositories: '[{"repository": "masterror"}, {"repository": "telegram-webapp-sdk"}]'
     secrets:
       CLASSIC: ${{ secrets.METRICS_TOKEN }}</code></pre>
 
@@ -133,11 +133,11 @@
   Use the open-source helper to normalize ad-hoc repository lists for the bundled workflow:
 </p>
 
-<pre><code class="language-bash">cargo run --manifest-path imir/Cargo.toml -- open-source --input '["masterror", "telegram-webapp-sdk"]'</code></pre>
+<pre><code class="language-bash">cargo run --manifest-path imir/Cargo.toml -- open-source --input '[{"repository": "masterror"}, {"repository": "telegram-webapp-sdk"}]'</code></pre>
 
 <p>
-  The command outputs the normalized JSON document that the workflow uses. The same CLI is invoked during CI, so validation errors
-  must be resolved locally before a workflow run succeeds.
+  The command outputs repository descriptors containing the slugged name and the contributors branch analyzed by the renderer.
+  The same CLI is invoked during CI, so validation errors must be resolved locally before a workflow run succeeds.
 </p>
 
 <p>Optional per-target overrides include:</p>
@@ -150,6 +150,11 @@
   <li><code>slug</code> – override the derived slug used for filenames and workflow dispatch names.</li>
   <li><code>include_private</code> – set to <code>true</code> to include private repositories and secret achievements for the target.</li>
 </ul>
+
+<p>
+  Contributor branch overrides are especially helpful for repositories that use a non-<code>main</code> default branch: the
+  generated metrics now highlight contributors for the correct branch without manual workflow edits.
+</p>
 
 <p>
   Unset overrides fall back to deterministic defaults chosen by the orchestrator, so adding a new target only requires the owner,

--- a/imir/src/lib.rs
+++ b/imir/src/lib.rs
@@ -44,10 +44,12 @@ pub use config::{
     BadgeOptions, BadgeStyle, BadgeWidgetAlignment, BadgeWidgetOptions, TargetConfig, TargetEntry,
     TargetKind,
 };
-pub use error::{io_error, Error};
+pub use error::{Error, io_error};
 pub use normalizer::{
-    load_targets, parse_targets, BadgeDescriptor, BadgeWidgetDescriptor, RenderTarget,
-    TargetsDocument,
+    BadgeDescriptor, BadgeWidgetDescriptor, RenderTarget, TargetsDocument, load_targets,
+    parse_targets,
 };
-pub use open_source::resolve_open_source_repositories;
+pub use open_source::{
+    OpenSourceRepository, resolve_open_source_repositories, resolve_open_source_targets,
+};
 pub use slug::SlugStrategy;

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -10,37 +10,34 @@ use std::{
 };
 
 use clap::{ArgAction, Args, Parser, Subcommand};
-use imir::{load_targets, resolve_open_source_repositories, Error, TargetsDocument};
+use imir::{Error, TargetsDocument, load_targets, resolve_open_source_targets};
 
 /// Command line interface for generating normalized metrics target definitions.
-#[derive(Debug, Parser,)]
+#[derive(Debug, Parser)]
 #[command(name = "imir", version, about = "Normalize metrics renderer targets")]
 /// Top-level CLI options parsed from user input.
-struct Cli
-{
+struct Cli {
     #[command(subcommand)]
-    command: Option<Command,>,
+    command: Option<Command>,
 
     /// Legacy argument support for the default targets command.
     #[command(flatten)]
     legacy: LegacyTargetsArgs,
 }
 
-#[derive(Debug, Subcommand,)]
+#[derive(Debug, Subcommand)]
 /// Supported commands exposed by the CLI.
-enum Command
-{
+enum Command {
     /// Normalize targets from a YAML configuration file.
-    Targets(TargetsArgs,),
+    Targets(TargetsArgs),
     /// Resolve repository inputs for the open-source render workflow.
     #[command(name = "open-source")]
-    OpenSource(OpenSourceArgs,),
+    OpenSource(OpenSourceArgs),
 }
 
-#[derive(Debug, Args,)]
+#[derive(Debug, Args)]
 /// Arguments accepted by the `targets` subcommand.
-struct TargetsArgs
-{
+struct TargetsArgs {
     /// Path to the YAML configuration file describing metrics targets.
     #[arg(long = "config", value_name = "PATH")]
     config: PathBuf,
@@ -51,32 +48,29 @@ struct TargetsArgs
 }
 
 /// Arguments accepted when the CLI is invoked without a subcommand.
-#[derive(Debug, Args, Default,)]
-struct LegacyTargetsArgs
-{
+#[derive(Debug, Args, Default)]
+struct LegacyTargetsArgs {
     /// Path to the YAML configuration file describing metrics targets.
     #[arg(long = "config", value_name = "PATH")]
-    config: Option<PathBuf,>,
+    config: Option<PathBuf>,
 
     /// Output formatted JSON for easier inspection.
     #[arg(long = "pretty", action = ArgAction::SetTrue)]
     pretty: bool,
 }
 
-#[derive(Debug, Args,)]
-struct OpenSourceArgs
-{
+#[derive(Debug, Args)]
+struct OpenSourceArgs {
     /// Raw repositories JSON provided by the workflow input.
     #[arg(long = "input", value_name = "JSON")]
-    input: Option<String,>,
+    input: Option<String>,
 }
 
 /// Entry point that reports errors and sets the appropriate exit status.
-fn main()
-{
-    if let Err(error,) = run() {
+fn main() {
+    if let Err(error) = run() {
         eprintln!("{}", error.to_display_string());
-        process::exit(1,);
+        process::exit(1);
     }
 }
 
@@ -85,45 +79,41 @@ fn main()
 /// # Errors
 ///
 /// Propagates errors originating from configuration loading and normalization.
-fn run() -> Result<(), Error,>
-{
+fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Command::Targets(args,),) => run_targets(args,),
-        Some(Command::OpenSource(args,),) => run_open_source(args,),
-        None => run_legacy_targets(&cli.legacy,),
+        Some(Command::Targets(args)) => run_targets(args),
+        Some(Command::OpenSource(args)) => run_open_source(args),
+        None => run_legacy_targets(&cli.legacy),
     }
 }
 
-fn run_targets(args: TargetsArgs,) -> Result<(), Error,>
-{
-    run_targets_from_path(&args.config, args.pretty,)
+fn run_targets(args: TargetsArgs) -> Result<(), Error> {
+    run_targets_from_path(&args.config, args.pretty)
 }
 
-fn run_targets_from_path(path: &Path, pretty: bool,) -> Result<(), Error,>
-{
-    let document = load_targets(path,)?;
+fn run_targets_from_path(path: &Path, pretty: bool) -> Result<(), Error> {
+    let document = load_targets(path)?;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    write_targets_document(&mut handle, &document, pretty,)
+    write_targets_document(&mut handle, &document, pretty)
 }
 
-fn write_targets_document<W: io::Write,>(
+fn write_targets_document<W: io::Write>(
     writer: &mut W,
     document: &TargetsDocument,
     pretty: bool,
-) -> Result<(), Error,>
-{
+) -> Result<(), Error> {
     if pretty {
-        serde_json::to_writer_pretty(writer, document,)?;
+        serde_json::to_writer_pretty(writer, document)?;
     } else {
-        serde_json::to_writer(writer, document,)?;
+        serde_json::to_writer(writer, document)?;
     }
 
-    Ok((),)
+    Ok(())
 }
 
 /// Handles the `open-source` subcommand by normalizing repository inputs.
@@ -132,44 +122,44 @@ fn write_targets_document<W: io::Write,>(
 ///
 /// Returns an [`Error`] when repository inputs are invalid or serialization
 /// fails.
-fn run_open_source(args: OpenSourceArgs,) -> Result<(), Error,>
-{
-    let trimmed = args.input.as_deref().map(str::trim,).filter(|value| !value.is_empty(),);
+fn run_open_source(args: OpenSourceArgs) -> Result<(), Error> {
+    let trimmed = args
+        .input
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
 
-    let repositories = resolve_open_source_repositories(trimmed,)?;
+    let targets = resolve_open_source_targets(trimmed)?;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
-    serde_json::to_writer(&mut handle, &repositories,)?;
+    serde_json::to_writer(&mut handle, &targets)?;
 
-    Ok((),)
+    Ok(())
 }
 
-fn run_legacy_targets(args: &LegacyTargetsArgs,) -> Result<(), Error,>
-{
+fn run_legacy_targets(args: &LegacyTargetsArgs) -> Result<(), Error> {
     let config = args
         .config
         .as_deref()
-        .ok_or_else(|| Error::validation("missing required --config <PATH> argument",),)?;
+        .ok_or_else(|| Error::validation("missing required --config <PATH> argument"))?;
 
-    run_targets_from_path(config, args.pretty,)
+    run_targets_from_path(config, args.pretty)
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use std::{io::Cursor, path::Path};
 
     use clap::Parser;
     use imir::TargetsDocument;
 
-    use super::{run_legacy_targets, write_targets_document, Cli, Command, LegacyTargetsArgs};
+    use super::{Cli, Command, LegacyTargetsArgs, run_legacy_targets, write_targets_document};
 
     #[test]
-    fn cli_accepts_legacy_targets_invocation()
-    {
-        let cli = Cli::try_parse_from([env!("CARGO_PKG_NAME"), "--config", "config.yaml",],)
-            .expect("failed to parse CLI",);
+    fn cli_accepts_legacy_targets_invocation() {
+        let cli = Cli::try_parse_from([env!("CARGO_PKG_NAME"), "--config", "config.yaml"])
+            .expect("failed to parse CLI");
 
         assert!(cli.command.is_none());
         assert_eq!(cli.legacy.config.as_deref(), Some(Path::new("config.yaml")));
@@ -177,15 +167,12 @@ mod tests
     }
 
     #[test]
-    fn legacy_targets_require_config_path()
-    {
+    fn legacy_targets_require_config_path() {
         let args = LegacyTargetsArgs::default();
-        let error = run_legacy_targets(&args,).expect_err("expected validation error",);
+        let error = run_legacy_targets(&args).expect_err("expected validation error");
 
         match error {
-            imir::Error::Validation {
-                message,
-            } => {
+            imir::Error::Validation { message } => {
                 assert_eq!(message, "missing required --config <PATH> argument");
             }
             other => panic!("unexpected error variant: {other:?}"),
@@ -193,19 +180,18 @@ mod tests
     }
 
     #[test]
-    fn targets_subcommand_pretty_flag_uses_pretty_writer()
-    {
+    fn targets_subcommand_pretty_flag_uses_pretty_writer() {
         let cli = Cli::try_parse_from([
             env!("CARGO_PKG_NAME"),
             "targets",
             "--config",
             "config.yaml",
             "--pretty",
-        ],)
-        .expect("failed to parse CLI",);
+        ])
+        .expect("failed to parse CLI");
 
-        let args = match cli.command.expect("missing targets command",) {
-            Command::Targets(args,) => args,
+        let args = match cli.command.expect("missing targets command") {
+            Command::Targets(args) => args,
             _ => panic!("unexpected command variant"),
         };
         assert!(args.pretty);
@@ -213,19 +199,18 @@ mod tests
         let document = TargetsDocument {
             targets: Vec::new(),
         };
-        let mut buffer = Cursor::new(Vec::new(),);
-        write_targets_document(&mut buffer, &document, args.pretty,)
-            .expect("failed to serialize targets",);
+        let mut buffer = Cursor::new(Vec::new());
+        write_targets_document(&mut buffer, &document, args.pretty)
+            .expect("failed to serialize targets");
 
-        let output = String::from_utf8(buffer.into_inner(),).expect("invalid UTF-8",);
+        let output = String::from_utf8(buffer.into_inner()).expect("invalid UTF-8");
         assert_eq!(output, "{\n  \"targets\": []\n}");
     }
 
     #[test]
-    fn legacy_invocation_without_pretty_uses_compact_writer()
-    {
-        let cli = Cli::try_parse_from([env!("CARGO_PKG_NAME"), "--config", "config.yaml",],)
-            .expect("failed to parse CLI",);
+    fn legacy_invocation_without_pretty_uses_compact_writer() {
+        let cli = Cli::try_parse_from([env!("CARGO_PKG_NAME"), "--config", "config.yaml"])
+            .expect("failed to parse CLI");
 
         assert!(cli.command.is_none());
         assert!(!cli.legacy.pretty);
@@ -233,11 +218,11 @@ mod tests
         let document = TargetsDocument {
             targets: Vec::new(),
         };
-        let mut buffer = Cursor::new(Vec::new(),);
-        write_targets_document(&mut buffer, &document, cli.legacy.pretty,)
-            .expect("failed to serialize targets",);
+        let mut buffer = Cursor::new(Vec::new());
+        write_targets_document(&mut buffer, &document, cli.legacy.pretty)
+            .expect("failed to serialize targets");
 
-        let output = String::from_utf8(buffer.into_inner(),).expect("invalid UTF-8",);
+        let output = String::from_utf8(buffer.into_inner()).expect("invalid UTF-8");
         assert_eq!(output, "{\"targets\":[]}");
     }
 }

--- a/imir/src/open_source.rs
+++ b/imir/src/open_source.rs
@@ -1,120 +1,205 @@
 //! Helpers for resolving open-source repository inputs supplied to workflows.
 //!
 //! The functions in this module sanitize and validate user-supplied JSON
-//! arrays before converting them into normalized repository name lists. The
-//! sanitization ensures downstream automation cannot be tricked into
-//! referencing empty or malformed entries.
+//! arrays before converting them into normalized repository descriptors. Each
+//! descriptor captures the repository name and the contributors branch so the
+//! renderer can display accurate contributor insights while remaining resilient
+//! to malformed input.
+
+use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 
 /// Default repositories used when the workflow input is omitted.
-const DEFAULT_REPOSITORIES: &[&str] = &["masterror", "telegram-webapp-sdk",];
+const DEFAULT_REPOSITORIES: &[&str] = &["masterror", "telegram-webapp-sdk"];
+const DEFAULT_CONTRIBUTORS_BRANCH: &str = "main";
 
-/// Resolves the repository list for the open-source workflow input.
+/// Normalized descriptor for an open-source repository entry.
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct OpenSourceRepository {
+    /// Repository name resolved from workflow input.
+    pub repository: String,
+    /// Branch analyzed by the contributors plugin.
+    pub contributors_branch: String,
+}
+
+/// Resolves repository descriptors for the open-source workflow input.
 ///
-/// The input must be a JSON array of repository names. Leading and trailing
-/// whitespace around individual entries is trimmed. When no input is provided
-/// the default repositories are returned.
+/// The input accepts a JSON array containing either bare repository names or
+/// objects with `repository` and optional `contributors_branch` fields. Leading
+/// and trailing whitespace around individual entries is trimmed. When no input
+/// is provided the default repositories are returned.
 ///
 /// # Errors
 ///
 /// Returns [`Error::Validation`](Error::Validation) when the input is not a
-/// valid JSON array of strings, contains empty entries, or expands to an empty
-/// list.
+/// valid JSON array, contains empty entries, or expands to an empty list.
 ///
 /// # Examples
 ///
 /// ```
-/// use imir::resolve_open_source_repositories;
+/// use imir::{resolve_open_source_targets, OpenSourceRepository};
 ///
-/// let repositories = resolve_open_source_repositories(Some("[\"repo\"]",),)?;
-/// assert_eq!(repositories, vec!["repo".to_owned()]);
+/// let targets = resolve_open_source_targets(Some("[{\"repository\":\"repo\"}]",),)?;
+/// assert_eq!(targets, vec![OpenSourceRepository {
+///     repository: "repo".to_owned(),
+///     contributors_branch: "main".to_owned(),
+/// }]);
 /// # Ok::<(), imir::Error>(())
 /// ```
-pub fn resolve_open_source_repositories(raw_input: Option<&str,>,)
-    -> Result<Vec<String,>, Error,>
-{
+pub fn resolve_open_source_targets(
+    raw_input: Option<&str>,
+) -> Result<Vec<OpenSourceRepository>, Error> {
     match raw_input.and_then(|value| {
         let trimmed = value.trim();
         if trimmed.is_empty() {
             None
         } else {
-            Some(trimmed,)
+            Some(trimmed)
         }
-    },)
-    {
-        Some(value,) => parse_user_supplied_repositories(value,),
-        None => Ok(default_repositories(),),
+    }) {
+        Some(value) => parse_user_supplied_repositories(value),
+        None => Ok(default_repositories()),
     }
 }
 
-/// Parses and validates repository names supplied as a JSON array.
+/// Resolves repository names without contributor metadata for compatibility.
+///
+/// This helper preserves the previous behaviour for callers that only require
+/// repository names.
+pub fn resolve_open_source_repositories(raw_input: Option<&str>) -> Result<Vec<String>, Error> {
+    let targets = resolve_open_source_targets(raw_input)?;
+    Ok(targets
+        .into_iter()
+        .map(|target| target.repository)
+        .collect())
+}
+
+/// Parses and validates repository descriptors supplied as a JSON array.
 ///
 /// # Errors
 ///
 /// Returns [`Error::Validation`](Error::Validation) when the JSON is invalid,
 /// expands to an empty array, or contains blank entries.
-fn parse_user_supplied_repositories(input: &str,) -> Result<Vec<String,>, Error,>
-{
-    let parsed: Vec<String,> = serde_json::from_str(input,)
-        .map_err(|error| Error::validation(format!("invalid repositories JSON: {error}"),),)?;
+fn parse_user_supplied_repositories(input: &str) -> Result<Vec<OpenSourceRepository>, Error> {
+    let parsed: Vec<RepositoryInput> = serde_json::from_str(input)
+        .map_err(|error| Error::validation(format!("invalid repositories JSON: {error}")))?;
 
     if parsed.is_empty() {
         return Err(Error::validation(
             "repositories input must be a non-empty JSON array of repository names",
-        ),);
+        ));
     }
 
-    let mut normalized = Vec::with_capacity(parsed.len(),);
+    let mut normalized = Vec::with_capacity(parsed.len());
     for repository in parsed {
-        let trimmed = repository.trim();
-        if trimmed.is_empty() {
-            return Err(Error::validation("repository names cannot be empty strings",),);
-        }
-        normalized.push(trimmed.to_owned(),);
+        let descriptor = match repository {
+            RepositoryInput::Name(name) => OpenSourceRepository {
+                repository: normalize_repository(&name)?,
+                contributors_branch: DEFAULT_CONTRIBUTORS_BRANCH.to_owned(),
+            },
+            RepositoryInput::Descriptor(descriptor) => {
+                let repository = normalize_repository(&descriptor.repository)?;
+                let contributors_branch = descriptor
+                    .contributors_branch
+                    .as_deref()
+                    .map(normalize_contributors_branch)
+                    .transpose()?
+                    .unwrap_or_else(|| DEFAULT_CONTRIBUTORS_BRANCH.to_owned());
+
+                OpenSourceRepository {
+                    repository,
+                    contributors_branch,
+                }
+            }
+        };
+
+        normalized.push(descriptor);
     }
 
-    Ok(normalized,)
+    Ok(normalized)
 }
 
-/// Returns the default repository list as owned strings.
-fn default_repositories() -> Vec<String,>
-{
-    let mut defaults = Vec::with_capacity(DEFAULT_REPOSITORIES.len(),);
+/// Returns the default repository descriptors when no input is supplied.
+fn default_repositories() -> Vec<OpenSourceRepository> {
+    let mut defaults = Vec::with_capacity(DEFAULT_REPOSITORIES.len());
     for repository in DEFAULT_REPOSITORIES {
-        defaults.push((*repository).to_owned(),);
+        defaults.push(OpenSourceRepository {
+            repository: (*repository).to_owned(),
+            contributors_branch: DEFAULT_CONTRIBUTORS_BRANCH.to_owned(),
+        });
     }
     defaults
 }
 
+fn normalize_repository(input: &str) -> Result<String, Error> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(Error::validation(
+            "repository names cannot be empty strings",
+        ));
+    }
+
+    Ok(trimmed.to_owned())
+}
+
+fn normalize_contributors_branch(input: &str) -> Result<String, Error> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(Error::validation("contributors_branch cannot be empty"));
+    }
+
+    if trimmed.chars().any(char::is_whitespace) {
+        return Err(Error::validation(
+            "contributors_branch cannot contain whitespace",
+        ));
+    }
+
+    Ok(trimmed.to_owned())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum RepositoryInput {
+    Name(String),
+    Descriptor(RepositoryDescriptor),
+}
+
+#[derive(Debug, Deserialize)]
+struct RepositoryDescriptor {
+    repository: String,
+    #[serde(default)]
+    contributors_branch: Option<String>,
+}
+
 #[cfg(test)]
-mod tests
-{
-    use super::resolve_open_source_repositories;
+mod tests {
+    use super::{
+        OpenSourceRepository, resolve_open_source_repositories, resolve_open_source_targets,
+    };
+    use crate::normalizer::DEFAULT_CONTRIBUTORS_BRANCH;
 
     #[test]
-    fn falls_back_to_defaults_when_input_missing()
-    {
-        let repositories = resolve_open_source_repositories(None,).expect("expected defaults",);
-        assert_eq!(repositories, vec!["masterror".to_owned(), "telegram-webapp-sdk".to_owned()]);
+    fn falls_back_to_defaults_when_input_missing() {
+        let repositories = resolve_open_source_repositories(None).expect("expected defaults");
+        assert_eq!(
+            repositories,
+            vec!["masterror".to_owned(), "telegram-webapp-sdk".to_owned()]
+        );
     }
 
     #[test]
-    fn trims_and_normalizes_entries()
-    {
-        let repositories = resolve_open_source_repositories(Some("[\" repo \", \"another\"]",),)
-            .expect("expected normalization",);
+    fn trims_and_normalizes_entries() {
+        let repositories = resolve_open_source_repositories(Some("[\" repo \", \"another\"]"))
+            .expect("expected normalization");
         assert_eq!(repositories, vec!["repo".to_owned(), "another".to_owned()]);
     }
 
     #[test]
-    fn rejects_empty_array()
-    {
-        let error = resolve_open_source_repositories(Some("[]",),).unwrap_err();
+    fn rejects_empty_array() {
+        let error = resolve_open_source_repositories(Some("[]")).unwrap_err();
         match error {
-            crate::Error::Validation {
-                message,
-            } => {
+            crate::Error::Validation { message } => {
                 assert_eq!(
                     message,
                     "repositories input must be a non-empty JSON array of repository names"
@@ -125,13 +210,10 @@ mod tests
     }
 
     #[test]
-    fn rejects_invalid_json()
-    {
-        let error = resolve_open_source_repositories(Some("not-json",),).unwrap_err();
+    fn rejects_invalid_json() {
+        let error = resolve_open_source_repositories(Some("not-json")).unwrap_err();
         match error {
-            crate::Error::Validation {
-                message,
-            } => {
+            crate::Error::Validation { message } => {
                 assert!(message.starts_with("invalid repositories JSON:"));
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -139,13 +221,10 @@ mod tests
     }
 
     #[test]
-    fn rejects_empty_entries()
-    {
-        let error = resolve_open_source_repositories(Some("[\"\", \"repo\"]",),).unwrap_err();
+    fn rejects_empty_entries() {
+        let error = resolve_open_source_repositories(Some("[\"\", \"repo\"]")).unwrap_err();
         match error {
-            crate::Error::Validation {
-                message,
-            } => {
+            crate::Error::Validation { message } => {
                 assert_eq!(message, "repository names cannot be empty strings");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -153,10 +232,57 @@ mod tests
     }
 
     #[test]
-    fn treats_whitespace_input_as_missing()
-    {
-        let repositories = resolve_open_source_repositories(Some("   ",),)
-            .expect("expected defaults when input whitespace",);
-        assert_eq!(repositories, vec!["masterror".to_owned(), "telegram-webapp-sdk".to_owned()]);
+    fn treats_whitespace_input_as_missing() {
+        let repositories = resolve_open_source_repositories(Some("   "))
+            .expect("expected defaults when input whitespace");
+        assert_eq!(
+            repositories,
+            vec!["masterror".to_owned(), "telegram-webapp-sdk".to_owned()]
+        );
+    }
+
+    #[test]
+    fn resolves_descriptors_with_default_branch() {
+        let targets = resolve_open_source_targets(Some("[\"repo\"]"))
+            .expect("expected descriptor resolution");
+
+        assert_eq!(
+            targets,
+            vec![OpenSourceRepository {
+                repository: "repo".to_owned(),
+                contributors_branch: DEFAULT_CONTRIBUTORS_BRANCH.to_owned(),
+            }]
+        );
+    }
+
+    #[test]
+    fn resolves_branch_override_with_trimming() {
+        let targets = resolve_open_source_targets(Some(
+            "[{\"repository\":\"repo\",\"contributors_branch\":\" feature/main \"}]",
+        ))
+        .expect("expected branch override");
+
+        assert_eq!(
+            targets,
+            vec![OpenSourceRepository {
+                repository: "repo".to_owned(),
+                contributors_branch: "feature/main".to_owned(),
+            }]
+        );
+    }
+
+    #[test]
+    fn rejects_branch_with_internal_whitespace() {
+        let error = resolve_open_source_targets(Some(
+            "[{\"repository\":\"repo\",\"contributors_branch\":\"feature main\"}]",
+        ))
+        .expect_err("expected branch validation error");
+
+        match error {
+            crate::Error::Validation { message } => {
+                assert_eq!(message, "contributors_branch cannot contain whitespace");
+            }
+            other => panic!("expected validation error, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend the `imir` open-source resolver to emit repository descriptors including the contributors branch and keep the legacy name-only helper for compatibility
- update the open-source workflow, README, and CLI wiring to consume the richer descriptors so contributors are rendered from the correct branch

## Testing
- cargo build --manifest-path imir/Cargo.toml --all-targets
- cargo test --manifest-path imir/Cargo.toml --all
- cargo clippy --manifest-path imir/Cargo.toml --all-targets -- -D warnings
- cargo doc --manifest-path imir/Cargo.toml --no-deps
- (cd imir && cargo audit)
- (cd imir && cargo deny check)


------
https://chatgpt.com/codex/tasks/task_e_68e07d136e60832ba8c3380716a54cd9