### PR TITLE
Fix open source default branch constant usage

### DIFF
--- a/imir/src/config.rs
+++ b/imir/src/config.rs
@@ -25,12 +25,11 @@ use crate::slug::SlugStrategy;
 /// let config: TargetConfig = serde_yaml::from_str(yaml,).expect("valid configuration",);
 /// assert_eq!(config.targets.len(), 1);
 /// ```
-#[derive(Debug, Deserialize,)]
-pub struct TargetConfig
-{
+#[derive(Debug, Deserialize)]
+pub struct TargetConfig {
     /// Collection of metrics targets to render.
     #[serde(default)]
-    pub targets: Vec<TargetEntry,>,
+    pub targets: Vec<TargetEntry>,
 }
 
 /// Raw configuration entry describing a single metrics target before
@@ -39,16 +38,15 @@ pub struct TargetConfig
 /// Instances are typically created by deserializing YAML documents. Helper
 /// methods are provided to derive slugs and display names in a consistent
 /// manner.
-#[derive(Debug, Deserialize, Clone,)]
-pub struct TargetEntry
-{
+#[derive(Debug, Deserialize, Clone)]
+pub struct TargetEntry {
     /// GitHub account that owns the repository or profile.
     #[serde(alias = "user")]
     pub owner: String,
 
     /// Optional repository name associated with the target.
     #[serde(default, alias = "repo")]
-    pub repository: Option<String,>,
+    pub repository: Option<String>,
 
     /// Logical target type that influences renderer presets.
     #[serde(rename = "type")]
@@ -56,11 +54,11 @@ pub struct TargetEntry
 
     /// Optional slug override used for filenames and branch names.
     #[serde(default)]
-    pub slug: Option<String,>,
+    pub slug: Option<String>,
 
     /// Optional branch name override for commits with refreshed metrics.
     #[serde(default, alias = "branch", alias = "branch-name", alias = "branchName")]
-    pub branch_name: Option<String,>,
+    pub branch_name: Option<String>,
 
     /// Optional branch name analyzed by the contributors plugin.
     #[serde(
@@ -69,23 +67,23 @@ pub struct TargetEntry
         alias = "contributors-branch",
         alias = "contributorsBranch"
     )]
-    pub contributors_branch: Option<String,>,
+    pub contributors_branch: Option<String>,
 
     /// Optional destination path override for the generated SVG artifact.
     #[serde(default)]
-    pub target_path: Option<String,>,
+    pub target_path: Option<String>,
 
     /// Optional temporary artifact override produced by the renderer.
     #[serde(default)]
-    pub temp_artifact: Option<String,>,
+    pub temp_artifact: Option<String>,
 
     /// Optional timezone override for renderer inputs.
     #[serde(default)]
-    pub time_zone: Option<String,>,
+    pub time_zone: Option<String>,
 
     /// Optional display name override used in commit messages.
     #[serde(default)]
-    pub display_name: Option<String,>,
+    pub display_name: Option<String>,
 
     /// Optional flag that enables private repository insights when set to
     /// `true`.
@@ -97,8 +95,7 @@ pub struct TargetEntry
     pub badge: Option<BadgeOptions>,
 }
 
-impl TargetEntry
-{
+impl TargetEntry {
     /// Returns the slug that should be used for this target.
     ///
     /// Custom overrides are normalized through [`SlugStrategy`] while
@@ -125,20 +122,20 @@ impl TargetEntry
     /// };
     /// assert_eq!(entry.resolved_slug().as_deref(), Some("metrics"));
     /// ```
-    pub fn resolved_slug(&self,) -> Option<String,>
-    {
-        if let Some(custom,) = self.slug.as_ref() {
-            return SlugStrategy::builder(custom,).build();
+    pub fn resolved_slug(&self) -> Option<String> {
+        if let Some(custom) = self.slug.as_ref() {
+            return SlugStrategy::builder(custom).build();
         }
 
         match self.target_type {
             TargetKind::Profile => {
                 let derived = format!("{}-profile", self.owner);
-                SlugStrategy::builder(&derived,).build()
+                SlugStrategy::builder(&derived).build()
             }
-            TargetKind::OpenSource | TargetKind::PrivateProject => {
-                self.repository.as_ref().and_then(|name| SlugStrategy::builder(name,).build(),)
-            }
+            TargetKind::OpenSource | TargetKind::PrivateProject => self
+                .repository
+                .as_ref()
+                .and_then(|name| SlugStrategy::builder(name).build()),
         }
     }
 
@@ -146,20 +143,19 @@ impl TargetEntry
     ///
     /// Leading and trailing whitespace is trimmed. When no override is
     /// supplied, the value falls back to "profile" or the repository name.
-    pub fn resolved_display_name(&self,) -> Option<String,>
-    {
-        if let Some(name,) = self.display_name.as_ref() {
+    pub fn resolved_display_name(&self) -> Option<String> {
+        if let Some(name) = self.display_name.as_ref() {
             let trimmed = name.trim();
             if trimmed.is_empty() {
                 return None;
             }
-            return Some(trimmed.to_owned(),);
+            return Some(trimmed.to_owned());
         }
 
         match self.target_type {
-            TargetKind::Profile => Some("profile".to_owned(),),
+            TargetKind::Profile => Some("profile".to_owned()),
             TargetKind::OpenSource | TargetKind::PrivateProject => {
-                self.repository.as_ref().map(|repo| repo.trim().to_owned(),)
+                self.repository.as_ref().map(|repo| repo.trim().to_owned())
             }
         }
     }
@@ -248,8 +244,9 @@ where
     D: serde::Deserializer<'de>,
 {
     let value: Option<u8> = Option::deserialize(deserializer)?;
-    if let Some(columns) = value && (columns == 0 || columns > 4) {
-
+    if let Some(columns) = value
+        && (columns == 0 || columns > 4)
+    {
         return Err(serde::de::Error::custom(
             "badge.widget.columns must be between 1 and 4",
         ));
@@ -262,7 +259,9 @@ where
     D: serde::Deserializer<'de>,
 {
     let value: Option<u8> = Option::deserialize(deserializer)?;
-    if let Some(radius) = value && radius > 32 {
+    if let Some(radius) = value
+        && radius > 32
+    {
         return Err(serde::de::Error::custom(
             "badge.widget.border_radius must not exceed 32",
         ));
@@ -274,16 +273,14 @@ where
 mod tests {
     use super::{BadgeOptions, BadgeStyle, BadgeWidgetAlignment, TargetEntry, TargetKind};
 
-
     #[test]
-    fn resolved_slug_prefers_custom_value()
-    {
+    fn resolved_slug_prefers_custom_value() {
         let entry = TargetEntry {
-            owner:               "octocat".to_owned(),
-            repository:          Some("Hello-World".to_owned(),),
-            target_type:         TargetKind::OpenSource,
-            slug:                Some("  Custom Slug  ".to_owned(),),
-            branch_name:         None,
+            owner: "octocat".to_owned(),
+            repository: Some("Hello-World".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: Some("  Custom Slug  ".to_owned()),
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -293,19 +290,20 @@ mod tests {
             badge: None,
         };
 
-        let slug = entry.resolved_slug().expect("expected slug to be derived from override",);
+        let slug = entry
+            .resolved_slug()
+            .expect("expected slug to be derived from override");
         assert_eq!(slug, "custom-slug");
     }
 
     #[test]
-    fn resolved_slug_falls_back_to_profile_default()
-    {
+    fn resolved_slug_falls_back_to_profile_default() {
         let entry = TargetEntry {
-            owner:               "octocat".to_owned(),
-            repository:          None,
-            target_type:         TargetKind::Profile,
-            slug:                None,
-            branch_name:         None,
+            owner: "octocat".to_owned(),
+            repository: None,
+            target_type: TargetKind::Profile,
+            slug: None,
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -315,19 +313,20 @@ mod tests {
             badge: None,
         };
 
-        let slug = entry.resolved_slug().expect("expected slug to be derived from owner",);
+        let slug = entry
+            .resolved_slug()
+            .expect("expected slug to be derived from owner");
         assert_eq!(slug, "octocat-profile");
     }
 
     #[test]
-    fn resolved_slug_falls_back_to_repository_name()
-    {
+    fn resolved_slug_falls_back_to_repository_name() {
         let entry = TargetEntry {
-            owner:               "octocat".to_owned(),
-            repository:          Some("Example Repo".to_owned(),),
-            target_type:         TargetKind::PrivateProject,
-            slug:                None,
-            branch_name:         None,
+            owner: "octocat".to_owned(),
+            repository: Some("Example Repo".to_owned()),
+            target_type: TargetKind::PrivateProject,
+            slug: None,
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -335,22 +334,22 @@ mod tests {
             display_name: None,
             include_private: None,
             badge: None,
-
         };
 
-        let slug = entry.resolved_slug().expect("expected slug to be derived from repository",);
+        let slug = entry
+            .resolved_slug()
+            .expect("expected slug to be derived from repository");
         assert_eq!(slug, "example-repo");
     }
 
     #[test]
-    fn resolved_slug_returns_none_when_unable_to_derive()
-    {
+    fn resolved_slug_returns_none_when_unable_to_derive() {
         let entry = TargetEntry {
-            owner:               "octocat".to_owned(),
-            repository:          Some("***".to_owned(),),
-            target_type:         TargetKind::OpenSource,
-            slug:                None,
-            branch_name:         None,
+            owner: "octocat".to_owned(),
+            repository: Some("***".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: None,
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -364,14 +363,13 @@ mod tests {
     }
 
     #[test]
-    fn resolved_display_name_prefers_override()
-    {
+    fn resolved_display_name_prefers_override() {
         let entry = TargetEntry {
-            owner:               "octocat".to_owned(),
-            repository:          Some("repo".to_owned(),),
-            target_type:         TargetKind::OpenSource,
-            slug:                None,
-            branch_name:         None,
+            owner: "octocat".to_owned(),
+            repository: Some("repo".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: None,
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -381,19 +379,20 @@ mod tests {
             badge: None,
         };
 
-        let display = entry.resolved_display_name().expect("expected display name to be derived",);
+        let display = entry
+            .resolved_display_name()
+            .expect("expected display name to be derived");
         assert_eq!(display, "Friendly Name");
     }
 
     #[test]
-    fn resolved_display_name_uses_repository_name()
-    {
+    fn resolved_display_name_uses_repository_name() {
         let entry = TargetEntry {
-            owner:               "octocat".to_owned(),
-            repository:          Some(" Repo With Spaces ".to_owned(),),
-            target_type:         TargetKind::OpenSource,
-            slug:                None,
-            branch_name:         None,
+            owner: "octocat".to_owned(),
+            repository: Some(" Repo With Spaces ".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: None,
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -403,19 +402,20 @@ mod tests {
             badge: None,
         };
 
-        let display = entry.resolved_display_name().expect("expected repository name to be used",);
+        let display = entry
+            .resolved_display_name()
+            .expect("expected repository name to be used");
         assert_eq!(display, "Repo With Spaces");
     }
 
     #[test]
-    fn resolved_display_name_returns_none_when_override_blank()
-    {
+    fn resolved_display_name_returns_none_when_override_blank() {
         let entry = TargetEntry {
-            owner:               "octocat".to_owned(),
-            repository:          None,
-            target_type:         TargetKind::Profile,
-            slug:                None,
-            branch_name:         None,
+            owner: "octocat".to_owned(),
+            repository: None,
+            target_type: TargetKind::Profile,
+            slug: None,
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -456,9 +456,11 @@ mod tests {
         "#;
 
         let error = serde_yaml::from_str::<BadgeOptions>(yaml).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("columns must be between 1 and 4"));
+        assert!(
+            error
+                .to_string()
+                .contains("columns must be between 1 and 4")
+        );
     }
 
     #[test]
@@ -469,17 +471,18 @@ mod tests {
         "#;
 
         let error = serde_yaml::from_str::<BadgeOptions>(yaml).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains("border_radius must not exceed 32"));
+        assert!(
+            error
+                .to_string()
+                .contains("border_radius must not exceed 32")
+        );
     }
 }
 
 /// Supported categories of metrics targets.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize,)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum TargetKind
-{
+pub enum TargetKind {
     /// Render a GitHub profile dashboard.
     Profile,
     /// Render an open-source repository dashboard.

--- a/imir/src/normalizer.rs
+++ b/imir/src/normalizer.rs
@@ -34,27 +34,26 @@ const DEFAULT_BADGE_ALIGNMENT: BadgeWidgetAlignment = BadgeWidgetAlignment::Star
 const DEFAULT_BADGE_BORDER_RADIUS: u8 = 4;
 
 /// Normalized representation of a metrics target used by automation workflows.
-#[derive(Debug, Serialize, Clone, PartialEq, Eq,)]
-pub struct RenderTarget
-{
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct RenderTarget {
     /// Unique slug derived from the configuration entry.
-    pub slug:                String,
+    pub slug: String,
     /// Account that owns the repository or profile.
-    pub owner:               String,
+    pub owner: String,
     /// Optional repository associated with the target.
-    pub repository:          Option<String,>,
+    pub repository: Option<String>,
     /// Target category.
-    pub kind:                TargetKind,
+    pub kind: TargetKind,
     /// Branch name used for storing refreshed metrics commits.
-    pub branch_name:         String,
+    pub branch_name: String,
     /// Final destination path for the generated SVG artifact.
-    pub target_path:         String,
+    pub target_path: String,
     /// Temporary artifact produced by the metrics renderer.
-    pub temp_artifact:       String,
+    pub temp_artifact: String,
     /// Time zone passed to the renderer.
-    pub time_zone:           String,
+    pub time_zone: String,
     /// Display name used in commit messages and logs.
-    pub display_name:        String,
+    pub display_name: String,
     /// Branch analyzed by the contributors plugin.
     pub contributors_branch: String,
     /// Flag indicating whether the renderer should include private repositories.
@@ -84,11 +83,10 @@ pub struct BadgeWidgetDescriptor {
 }
 
 /// Document containing all normalized targets.
-#[derive(Debug, Serialize, Clone, PartialEq, Eq,)]
-pub struct TargetsDocument
-{
+#[derive(Debug, Serialize, Clone, PartialEq, Eq)]
+pub struct TargetsDocument {
     /// Aggregated targets derived from the configuration.
-    pub targets: Vec<RenderTarget,>,
+    pub targets: Vec<RenderTarget>,
 }
 
 /// Loads targets from the provided YAML configuration file path.
@@ -97,10 +95,9 @@ pub struct TargetsDocument
 ///
 /// Returns an [`Error`] when the file cannot be read, the YAML cannot be
 /// deserialized, or the configuration violates invariants during normalization.
-pub fn load_targets(path: &Path,) -> Result<TargetsDocument, Error,>
-{
-    let contents = fs::read_to_string(path,).map_err(|source| error::io_error(path, source,),)?;
-    parse_targets(&contents,)
+pub fn load_targets(path: &Path) -> Result<TargetsDocument, Error> {
+    let contents = fs::read_to_string(path).map_err(|source| error::io_error(path, source))?;
+    parse_targets(&contents)
 }
 
 /// Parses targets from the provided YAML document string.
@@ -113,14 +110,15 @@ pub fn load_targets(path: &Path,) -> Result<TargetsDocument, Error,>
 /// Propagates [`Error::Parse`](Error::Parse) when the YAML cannot be decoded
 /// and [`Error::Validation`](Error::Validation) when required entries are
 /// missing.
-pub fn parse_targets(contents: &str,) -> Result<TargetsDocument, Error,>
-{
-    let config: TargetConfig = serde_yaml::from_str(contents,)?;
+pub fn parse_targets(contents: &str) -> Result<TargetsDocument, Error> {
+    let config: TargetConfig = serde_yaml::from_str(contents)?;
     if config.targets.is_empty() {
-        return Err(Error::validation("configuration must include at least one target",),);
+        return Err(Error::validation(
+            "configuration must include at least one target",
+        ));
     }
 
-    normalize_targets(&config.targets,)
+    normalize_targets(&config.targets)
 }
 
 /// Normalizes raw configuration entries into a deduplicated document.
@@ -129,45 +127,47 @@ pub fn parse_targets(contents: &str,) -> Result<TargetsDocument, Error,>
 ///
 /// Returns [`Error::Validation`](Error::Validation) when collisions are
 /// detected across slugs, branch names, target paths, or temporary artifacts.
-fn normalize_targets(entries: &[TargetEntry],) -> Result<TargetsDocument, Error,>
-{
-    let mut normalized = Vec::with_capacity(entries.len(),);
-    let mut seen_slugs = HashSet::with_capacity(entries.len(),);
-    let mut seen_paths = HashSet::with_capacity(entries.len(),);
-    let mut seen_temp = HashSet::with_capacity(entries.len(),);
-    let mut seen_branches = HashSet::with_capacity(entries.len(),);
+fn normalize_targets(entries: &[TargetEntry]) -> Result<TargetsDocument, Error> {
+    let mut normalized = Vec::with_capacity(entries.len());
+    let mut seen_slugs = HashSet::with_capacity(entries.len());
+    let mut seen_paths = HashSet::with_capacity(entries.len());
+    let mut seen_temp = HashSet::with_capacity(entries.len());
+    let mut seen_branches = HashSet::with_capacity(entries.len());
 
     for entry in entries {
-        let target = normalize_entry(entry,)?;
+        let target = normalize_entry(entry)?;
 
-        if !seen_slugs.insert(target.slug.clone(),) {
-            return Err(Error::validation(format!("duplicate slug '{}'", target.slug),),);
+        if !seen_slugs.insert(target.slug.clone()) {
+            return Err(Error::validation(format!(
+                "duplicate slug '{}'",
+                target.slug
+            )));
         }
-        if !seen_paths.insert(target.target_path.clone(),) {
+        if !seen_paths.insert(target.target_path.clone()) {
             return Err(Error::validation(format!(
                 "duplicate target_path '{}'",
                 target.target_path
-            ),),);
+            )));
         }
-        if !seen_temp.insert(target.temp_artifact.clone(),) {
+        if !seen_temp.insert(target.temp_artifact.clone()) {
             return Err(Error::validation(format!(
                 "duplicate temp_artifact '{}'",
                 target.temp_artifact
-            ),),);
+            )));
         }
-        if !seen_branches.insert(target.branch_name.clone(),) {
+        if !seen_branches.insert(target.branch_name.clone()) {
             return Err(Error::validation(format!(
                 "duplicate branch_name '{}'",
                 target.branch_name
-            ),),);
+            )));
         }
 
-        normalized.push(target,);
+        normalized.push(target);
     }
 
     Ok(TargetsDocument {
         targets: normalized,
-    },)
+    })
 }
 
 /// Converts a raw configuration entry into a normalized render target.
@@ -176,62 +176,60 @@ fn normalize_targets(entries: &[TargetEntry],) -> Result<TargetsDocument, Error,
 ///
 /// Returns [`Error::Validation`](Error::Validation) when required fields are
 /// missing or contain disallowed characters.
-fn normalize_entry(entry: &TargetEntry,) -> Result<RenderTarget, Error,>
-{
-    let owner = normalize_identifier(&entry.owner, "owner",)?;
+fn normalize_entry(entry: &TargetEntry) -> Result<RenderTarget, Error> {
+    let owner = normalize_identifier(&entry.owner, "owner")?;
 
     let repository = match entry.target_type {
         TargetKind::Profile => None,
         TargetKind::OpenSource | TargetKind::PrivateProject => {
             let repo_name = entry.repository.as_ref().ok_or_else(|| {
-                Error::validation("repository is required for repository targets",)
-            },)?;
-            Some(normalize_identifier(repo_name, "repository",)?,)
+                Error::validation("repository is required for repository targets")
+            })?;
+            Some(normalize_identifier(repo_name, "repository")?)
         }
     };
 
     let slug = entry
         .resolved_slug()
-        .ok_or_else(|| Error::validation("unable to derive slug for target",),)?;
+        .ok_or_else(|| Error::validation("unable to derive slug for target"))?;
 
     let branch_name = match entry.branch_name.as_ref() {
-        Some(custom,) => normalize_path_like(custom, "branch_name",)?,
+        Some(custom) => normalize_path_like(custom, "branch_name")?,
         None => format!("{DEFAULT_BRANCH_PREFIX}{slug}"),
     };
 
     let target_path = match entry.target_path.as_ref() {
-        Some(custom,) => normalize_path_like(custom, "target_path",)?,
+        Some(custom) => normalize_path_like(custom, "target_path")?,
         None => format!("{DEFAULT_OUTPUT_DIR}/{slug}.{DEFAULT_EXTENSION}"),
     };
 
     let temp_artifact = match entry.temp_artifact.as_ref() {
-        Some(custom,) => normalize_path_like(custom, "temp_artifact",)?,
+        Some(custom) => normalize_path_like(custom, "temp_artifact")?,
         None => format!("{DEFAULT_TEMP_DIR}/{slug}.{DEFAULT_EXTENSION}"),
     };
 
     let time_zone = entry
         .time_zone
         .as_ref()
-        .map(|value| value.trim(),)
-        .filter(|value| !value.is_empty(),)
-        .map_or_else(|| DEFAULT_TIME_ZONE.to_owned(), |value| value.to_owned(),);
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map_or_else(|| DEFAULT_TIME_ZONE.to_owned(), |value| value.to_owned());
 
     let display_name = entry
         .resolved_display_name()
-        .ok_or_else(|| Error::validation("unable to derive display name for target",),)?;
+        .ok_or_else(|| Error::validation("unable to derive display name for target"))?;
 
     let contributors_branch = entry
         .contributors_branch
         .as_ref()
-        .map(|value| normalize_identifier(value, "contributors_branch",),)
+        .map(|value| normalize_identifier(value, "contributors_branch"))
         .transpose()?
-        .unwrap_or_else(|| DEFAULT_CONTRIBUTORS_BRANCH.to_owned(),);
+        .unwrap_or_else(|| DEFAULT_CONTRIBUTORS_BRANCH.to_owned());
 
     let include_private = entry
         .include_private
-        .unwrap_or_else(|| default_include_private(&owner, entry.target_type,),);
+        .unwrap_or_else(|| default_include_private(&owner, entry.target_type));
     let badge = normalize_badge(entry.badge.as_ref())?;
-
 
     Ok(RenderTarget {
         slug,
@@ -249,8 +247,7 @@ fn normalize_entry(entry: &TargetEntry,) -> Result<RenderTarget, Error,>
     })
 }
 
-fn default_include_private(owner: &str, kind: TargetKind,) -> bool
-{
+fn default_include_private(owner: &str, kind: TargetKind) -> bool {
     matches!(kind, TargetKind::Profile,) && owner == "RAprogramm"
 }
 
@@ -307,16 +304,17 @@ fn validate_badge_border_radius(value: u8) -> Result<u8, Error> {
 ///
 /// Returns [`Error::Validation`](Error::Validation) when the value is empty or
 /// contains whitespace.
-fn normalize_identifier(input: &str, field: &str,) -> Result<String, Error,>
-{
+fn normalize_identifier(input: &str, field: &str) -> Result<String, Error> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
-        return Err(Error::validation(format!("{field} cannot be empty"),),);
+        return Err(Error::validation(format!("{field} cannot be empty")));
     }
-    if trimmed.chars().any(char::is_whitespace,) {
-        return Err(Error::validation(format!("{field} cannot contain whitespace"),),);
+    if trimmed.chars().any(char::is_whitespace) {
+        return Err(Error::validation(format!(
+            "{field} cannot contain whitespace"
+        )));
     }
-    Ok(trimmed.to_owned(),)
+    Ok(trimmed.to_owned())
 }
 
 /// Validates path-like overrides supplied in the configuration.
@@ -325,36 +323,35 @@ fn normalize_identifier(input: &str, field: &str,) -> Result<String, Error,>
 ///
 /// Returns [`Error::Validation`](Error::Validation) when the override is
 /// blank after trimming whitespace.
-fn normalize_path_like(input: &str, field: &str,) -> Result<String, Error,>
-{
+fn normalize_path_like(input: &str, field: &str) -> Result<String, Error> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
-        return Err(Error::validation(format!("{field} override cannot be empty"),),);
+        return Err(Error::validation(format!(
+            "{field} override cannot be empty"
+        )));
     }
-    Ok(trimmed.to_owned(),)
+    Ok(trimmed.to_owned())
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use std::io::Write;
 
     use super::{
-        load_targets, normalize_entry, normalize_identifier, normalize_path_like,
-        normalize_targets, parse_targets, Error,
+        Error, load_targets, normalize_entry, normalize_identifier, normalize_path_like,
+        normalize_targets, parse_targets,
     };
     use crate::config::{
         BadgeOptions, BadgeStyle, BadgeWidgetAlignment, BadgeWidgetOptions, TargetEntry, TargetKind,
     };
 
-    fn repository_entry() -> TargetEntry
-    {
+    fn repository_entry() -> TargetEntry {
         TargetEntry {
-            owner:               "RAprogramm".to_owned(),
-            repository:          Some("metrics".to_owned(),),
-            target_type:         TargetKind::OpenSource,
-            slug:                None,
-            branch_name:         None,
+            owner: "RAprogramm".to_owned(),
+            repository: Some("metrics".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: None,
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -365,30 +362,28 @@ mod tests
         }
     }
 
-    fn profile_entry(owner: &str,) -> TargetEntry
-    {
+    fn profile_entry(owner: &str) -> TargetEntry {
         TargetEntry {
-            owner:               owner.to_owned(),
-            repository:          None,
-            target_type:         TargetKind::Profile,
-            slug:                None,
-            branch_name:         None,
+            owner: owner.to_owned(),
+            repository: None,
+            target_type: TargetKind::Profile,
+            slug: None,
+            branch_name: None,
             contributors_branch: None,
-            target_path:         None,
-            temp_artifact:       None,
-            time_zone:           None,
-            display_name:        None,
-            include_private:     None,
-            badge:               None,
+            target_path: None,
+            temp_artifact: None,
+            time_zone: None,
+            display_name: None,
+            include_private: None,
+            badge: None,
         }
     }
 
     #[test]
-    fn normalizes_repository_entry()
-    {
+    fn normalizes_repository_entry() {
         let entry = repository_entry();
 
-        let target = normalize_entry(&entry,).expect("expected normalization success",);
+        let target = normalize_entry(&entry).expect("expected normalization success");
         assert_eq!(target.slug, "metrics");
         assert_eq!(target.branch_name, "ci/metrics-refresh-metrics");
         assert_eq!(target.target_path, "metrics/metrics.svg");
@@ -403,44 +398,40 @@ mod tests
     }
 
     #[test]
-    fn normalizes_include_private_flag_values()
-    {
+    fn normalizes_include_private_flag_values() {
         let mut enabled = repository_entry();
-        enabled.include_private = Some(true,);
-        let target = normalize_entry(&enabled,).expect("expected include_private to normalize",);
+        enabled.include_private = Some(true);
+        let target = normalize_entry(&enabled).expect("expected include_private to normalize");
         assert!(target.include_private);
 
         let mut disabled = repository_entry();
-        disabled.include_private = Some(false,);
-        let target = normalize_entry(&disabled,).expect("expected include_private to normalize",);
+        disabled.include_private = Some(false);
+        let target = normalize_entry(&disabled).expect("expected include_private to normalize");
         assert!(!target.include_private);
     }
 
     #[test]
-    fn defaults_include_private_for_raprogramm_profile()
-    {
-        let entry = profile_entry("RAprogramm",);
-        let target = normalize_entry(&entry,).expect("expected include_private default",);
+    fn defaults_include_private_for_raprogramm_profile() {
+        let entry = profile_entry("RAprogramm");
+        let target = normalize_entry(&entry).expect("expected include_private default");
         assert!(target.include_private);
     }
 
     #[test]
-    fn profile_targets_for_other_owners_default_to_public_only()
-    {
-        let entry = profile_entry("octocat",);
-        let target = normalize_entry(&entry,).expect("expected include_private default",);
+    fn profile_targets_for_other_owners_default_to_public_only() {
+        let entry = profile_entry("octocat");
+        let target = normalize_entry(&entry).expect("expected include_private default");
         assert!(!target.include_private);
     }
 
     #[test]
-    fn normalizes_infra_metrics_insight_renderer_target()
-    {
+    fn normalizes_infra_metrics_insight_renderer_target() {
         let entry = TargetEntry {
-            owner:               "RAprogramm".to_owned(),
-            repository:          Some("infra-metrics-insight-renderer".to_owned(),),
-            target_type:         TargetKind::OpenSource,
-            slug:                Some("infra-metrics-insight-renderer".to_owned(),),
-            branch_name:         None,
+            owner: "RAprogramm".to_owned(),
+            repository: Some("infra-metrics-insight-renderer".to_owned()),
+            target_type: TargetKind::OpenSource,
+            slug: Some("infra-metrics-insight-renderer".to_owned()),
+            branch_name: None,
             contributors_branch: None,
             target_path: None,
             temp_artifact: None,
@@ -450,11 +441,20 @@ mod tests
             badge: None,
         };
 
-        let target = normalize_entry(&entry,).expect("expected target to normalize",);
+        let target = normalize_entry(&entry).expect("expected target to normalize");
         assert_eq!(target.slug, "infra-metrics-insight-renderer");
-        assert_eq!(target.branch_name, "ci/metrics-refresh-infra-metrics-insight-renderer");
-        assert_eq!(target.target_path, "metrics/infra-metrics-insight-renderer.svg");
-        assert_eq!(target.temp_artifact, ".metrics-tmp/infra-metrics-insight-renderer.svg");
+        assert_eq!(
+            target.branch_name,
+            "ci/metrics-refresh-infra-metrics-insight-renderer"
+        );
+        assert_eq!(
+            target.target_path,
+            "metrics/infra-metrics-insight-renderer.svg"
+        );
+        assert_eq!(
+            target.temp_artifact,
+            ".metrics-tmp/infra-metrics-insight-renderer.svg"
+        );
         assert_eq!(target.time_zone, "Asia/Ho_Chi_Minh");
         assert_eq!(target.display_name, "Infra Metrics Insight Renderer");
         assert_eq!(target.contributors_branch, "main");
@@ -462,14 +462,13 @@ mod tests
     }
 
     #[test]
-    fn normalizes_profile_entry_with_overrides()
-    {
+    fn normalizes_profile_entry_with_overrides() {
         let entry = TargetEntry {
-            owner:               " Octocat ".to_owned(),
-            repository:          None,
-            target_type:         TargetKind::Profile,
-            slug:                Some(" Custom.Profile ".to_owned(),),
-            branch_name:         Some("  feature/metrics  ".to_owned(),),
+            owner: " Octocat ".to_owned(),
+            repository: None,
+            target_type: TargetKind::Profile,
+            slug: Some(" Custom.Profile ".to_owned()),
+            branch_name: Some("  feature/metrics  ".to_owned()),
             contributors_branch: None,
             target_path: Some("  dashboards/profile.svg  ".to_owned()),
             temp_artifact: Some("  tmp/profile.svg  ".to_owned()),
@@ -479,7 +478,7 @@ mod tests
             badge: None,
         };
 
-        let target = normalize_entry(&entry,).expect("expected overrides to be honored",);
+        let target = normalize_entry(&entry).expect("expected overrides to be honored");
         assert_eq!(target.slug, "custom-profile");
         assert_eq!(target.branch_name, "feature/metrics");
         assert_eq!(target.target_path, "dashboards/profile.svg");
@@ -552,83 +551,74 @@ mod tests
     }
 
     #[test]
-    fn normalizes_contributors_branch_override()
-    {
+    fn normalizes_contributors_branch_override() {
         let mut entry = repository_entry();
-        entry.contributors_branch = Some(" feature/main ".to_owned(),);
+        entry.contributors_branch = Some(" feature/main ".to_owned());
 
-        let target = normalize_entry(&entry,).expect("expected contributors branch override",);
+        let target = normalize_entry(&entry).expect("expected contributors branch override");
         assert_eq!(target.contributors_branch, "feature/main");
     }
 
     #[test]
-    fn rejects_missing_repository_for_repository_target()
-    {
+    fn rejects_missing_repository_for_repository_target() {
         let entry = TargetEntry {
             repository: None,
             ..repository_entry()
         };
 
-        let result = normalize_entry(&entry,);
+        let result = normalize_entry(&entry);
         assert!(result.is_err());
     }
 
     #[test]
-    fn prevents_duplicate_slugs()
-    {
+    fn prevents_duplicate_slugs() {
         let entries = vec![repository_entry(), repository_entry()];
 
-        let result = normalize_targets(&entries,);
+        let result = normalize_targets(&entries);
         assert!(result.is_err());
     }
 
     #[test]
-    fn prevents_duplicate_target_paths()
-    {
+    fn prevents_duplicate_target_paths() {
         let mut a = repository_entry();
-        a.target_path = Some("custom/path.svg".to_owned(),);
+        a.target_path = Some("custom/path.svg".to_owned());
         let mut b = repository_entry();
-        b.slug = Some("other".to_owned(),);
-        b.target_path = Some("custom/path.svg".to_owned(),);
+        b.slug = Some("other".to_owned());
+        b.target_path = Some("custom/path.svg".to_owned());
 
-        let result = normalize_targets(&[a, b,],);
+        let result = normalize_targets(&[a, b]);
         assert!(result.is_err());
     }
 
     #[test]
-    fn prevents_duplicate_temp_artifacts()
-    {
+    fn prevents_duplicate_temp_artifacts() {
         let mut a = repository_entry();
-        a.temp_artifact = Some("tmp/output.svg".to_owned(),);
+        a.temp_artifact = Some("tmp/output.svg".to_owned());
         let mut b = repository_entry();
-        b.slug = Some("other".to_owned(),);
-        b.temp_artifact = Some("tmp/output.svg".to_owned(),);
+        b.slug = Some("other".to_owned());
+        b.temp_artifact = Some("tmp/output.svg".to_owned());
 
-        let result = normalize_targets(&[a, b,],);
+        let result = normalize_targets(&[a, b]);
         assert!(result.is_err());
     }
 
     #[test]
-    fn prevents_duplicate_branch_names()
-    {
+    fn prevents_duplicate_branch_names() {
         let mut a = repository_entry();
-        a.branch_name = Some("ci/branch".to_owned(),);
+        a.branch_name = Some("ci/branch".to_owned());
         let mut b = repository_entry();
-        b.slug = Some("other".to_owned(),);
-        b.branch_name = Some("ci/branch".to_owned(),);
+        b.slug = Some("other".to_owned());
+        b.branch_name = Some("ci/branch".to_owned());
 
-        let result = normalize_targets(&[a, b,],);
+        let result = normalize_targets(&[a, b]);
         assert!(result.is_err());
     }
 
     #[test]
-    fn normalize_identifier_rejects_whitespace()
-    {
-        let error = normalize_identifier("bad value", "field",).unwrap_err();
+    fn normalize_identifier_rejects_whitespace() {
+        let error = normalize_identifier("bad value", "field").unwrap_err();
         match error {
-            Error::Validation {
-                message,
-            } => {
+            Error::Validation { message } => {
                 assert_eq!(message, "field cannot contain whitespace");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -636,13 +626,10 @@ mod tests
     }
 
     #[test]
-    fn normalize_identifier_rejects_empty()
-    {
-        let error = normalize_identifier("   ", "field",).unwrap_err();
+    fn normalize_identifier_rejects_empty() {
+        let error = normalize_identifier("   ", "field").unwrap_err();
         match error {
-            Error::Validation {
-                message,
-            } => {
+            Error::Validation { message } => {
                 assert_eq!(message, "field cannot be empty");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -650,21 +637,17 @@ mod tests
     }
 
     #[test]
-    fn normalize_path_like_trims_values()
-    {
-        let normalized = normalize_path_like("  path/value  ", "field",)
-            .expect("expected normalization success",);
+    fn normalize_path_like_trims_values() {
+        let normalized =
+            normalize_path_like("  path/value  ", "field").expect("expected normalization success");
         assert_eq!(normalized, "path/value");
     }
 
     #[test]
-    fn normalize_path_like_rejects_empty()
-    {
-        let error = normalize_path_like("   ", "field",).unwrap_err();
+    fn normalize_path_like_rejects_empty() {
+        let error = normalize_path_like("   ", "field").unwrap_err();
         match error {
-            Error::Validation {
-                message,
-            } => {
+            Error::Validation { message } => {
                 assert_eq!(message, "field override cannot be empty");
             }
             other => panic!("expected validation error, got {other:?}"),
@@ -672,15 +655,13 @@ mod tests
     }
 
     #[test]
-    fn parse_targets_rejects_empty_configuration()
-    {
-        let result = parse_targets("targets: []",);
+    fn parse_targets_rejects_empty_configuration() {
+        let result = parse_targets("targets: []");
         assert!(result.is_err());
     }
 
     #[test]
-    fn parse_targets_handles_valid_document()
-    {
+    fn parse_targets_handles_valid_document() {
         let yaml = r#"
             targets:
               - owner: octocat
@@ -688,13 +669,12 @@ mod tests
                 type: open_source
         "#;
 
-        let document = parse_targets(yaml,).expect("expected parse success",);
+        let document = parse_targets(yaml).expect("expected parse success");
         assert_eq!(document.targets.len(), 1);
     }
 
     #[test]
-    fn parse_targets_supports_branch_alias()
-    {
+    fn parse_targets_supports_branch_alias() {
         let yaml = r#"
             targets:
               - owner: octocat
@@ -703,7 +683,7 @@ mod tests
                 branch:  feature/metrics
         "#;
 
-        let document = parse_targets(yaml,).expect("expected parse success",);
+        let document = parse_targets(yaml).expect("expected parse success");
         assert_eq!(document.targets.len(), 1);
         assert_eq!(document.targets[0].branch_name, "feature/metrics");
     }
@@ -753,9 +733,11 @@ mod tests
         let error = parse_targets(yaml).expect_err("expected badge validation failure");
         match error {
             Error::Parse { ref source } => {
-                assert!(source
-                    .to_string()
-                    .contains("badge.widget.columns must be between 1 and 4"));
+                assert!(
+                    source
+                        .to_string()
+                        .contains("badge.widget.columns must be between 1 and 4")
+                );
             }
             other => panic!("expected parse error, got {other:?}"),
         }
@@ -764,26 +746,28 @@ mod tests
     #[test]
     fn normalized_document_preserves_order() {
         let mut first = repository_entry();
-        first.slug = Some("first".to_owned(),);
+        first.slug = Some("first".to_owned());
         let mut second = repository_entry();
-        second.slug = Some("second".to_owned(),);
+        second.slug = Some("second".to_owned());
 
-        let document =
-            normalize_targets(&[first, second,],).expect("expected normalization success",);
-        let slugs: Vec<_,> = document.targets.iter().map(|target| target.slug.as_str(),).collect();
+        let document = normalize_targets(&[first, second]).expect("expected normalization success");
+        let slugs: Vec<_> = document
+            .targets
+            .iter()
+            .map(|target| target.slug.as_str())
+            .collect();
         assert_eq!(slugs, ["first", "second"]);
     }
 
     #[test]
-    fn render_target_equality_covers_all_fields()
-    {
-        let base = normalize_entry(&repository_entry(),).expect("expected success",);
+    fn render_target_equality_covers_all_fields() {
+        let base = normalize_entry(&repository_entry()).expect("expected success");
         let mut clone = base.clone();
         assert_eq!(base, clone);
-        clone.branch_name.push_str("-extra",);
+        clone.branch_name.push_str("-extra");
         assert_ne!(base, clone);
         let mut clone = base.clone();
-        clone.contributors_branch.push_str("-feature",);
+        clone.contributors_branch.push_str("-feature");
         assert_ne!(base, clone);
         let mut clone = base.clone();
         clone.badge.widget.columns = 2;
@@ -791,22 +775,23 @@ mod tests
     }
 
     #[test]
-    fn load_targets_reads_configuration_from_disk()
-    {
-        let mut file = tempfile::NamedTempFile::new().expect("expected temp file",);
-        write!(file, "targets:\n  - owner: octocat\n    repo: metrics\n    type: open_source\n")
-            .expect("expected write to succeed",);
+    fn load_targets_reads_configuration_from_disk() {
+        let mut file = tempfile::NamedTempFile::new().expect("expected temp file");
+        write!(
+            file,
+            "targets:\n  - owner: octocat\n    repo: metrics\n    type: open_source\n"
+        )
+        .expect("expected write to succeed");
 
-        let document = load_targets(file.path(),).expect("expected load to succeed",);
+        let document = load_targets(file.path()).expect("expected load to succeed");
         assert_eq!(document.targets.len(), 1);
         assert_eq!(document.targets[0].owner, "octocat");
     }
 
     #[test]
-    fn load_targets_reports_io_errors()
-    {
-        let path = std::path::Path::new("/nonexistent/config.yaml",);
-        let error = load_targets(path,).expect_err("expected io error",);
+    fn load_targets_reports_io_errors() {
+        let path = std::path::Path::new("/nonexistent/config.yaml");
+        let error = load_targets(path).expect_err("expected io error");
         assert!(matches!(error, Error::Io { .. }));
     }
 }

--- a/imir/src/open_source.rs
+++ b/imir/src/open_source.rs
@@ -175,9 +175,9 @@ struct RepositoryDescriptor {
 #[cfg(test)]
 mod tests {
     use super::{
-        OpenSourceRepository, resolve_open_source_repositories, resolve_open_source_targets,
+        DEFAULT_CONTRIBUTORS_BRANCH, OpenSourceRepository, resolve_open_source_repositories,
+        resolve_open_source_targets,
     };
-    use crate::normalizer::DEFAULT_CONTRIBUTORS_BRANCH;
 
     #[test]
     fn falls_back_to_defaults_when_input_missing() {

--- a/imir/src/slug.rs
+++ b/imir/src/slug.rs
@@ -5,23 +5,18 @@
 //! names and filesystem paths across platforms.
 
 /// Builder for slug strings that can be used for branch names and filenames.
-#[derive(Debug, Clone, Copy,)]
-pub struct SlugStrategy<'input,>
-{
+#[derive(Debug, Clone, Copy)]
+pub struct SlugStrategy<'input> {
     source: &'input str,
 }
 
-impl<'input,> SlugStrategy<'input,>
-{
+impl<'input> SlugStrategy<'input> {
     /// Creates a new slug builder for the provided string slice.
     ///
     /// The builder retains a borrowed view of the source to avoid allocations
     /// until [`build`](Self::build) is invoked.
-    pub fn builder(source: &'input str,) -> Self
-    {
-        Self {
-            source,
-        }
+    pub fn builder(source: &'input str) -> Self {
+        Self { source }
     }
 
     /// Builds a slug from the provided source string. The slug contains only
@@ -37,56 +32,50 @@ impl<'input,> SlugStrategy<'input,>
     /// let slug = SlugStrategy::builder(" Docs/Overview  ",).build();
     /// assert_eq!(slug.as_deref(), Some("docs-overview"));
     /// ```
-    pub fn build(self,) -> Option<String,>
-    {
+    pub fn build(self) -> Option<String> {
         let trimmed = self.source.trim();
         if trimmed.is_empty() {
             return None;
         }
 
-        let mut slug = String::with_capacity(trimmed.len(),);
+        let mut slug = String::with_capacity(trimmed.len());
         let mut previous_hyphen = false;
 
         for candidate in trimmed.chars() {
             match candidate {
                 'A'..='Z' => {
-                    slug.push(candidate.to_ascii_lowercase(),);
+                    slug.push(candidate.to_ascii_lowercase());
                     previous_hyphen = false;
                 }
                 'a'..='z' | '0'..='9' => {
-                    slug.push(candidate,);
+                    slug.push(candidate);
                     previous_hyphen = false;
                 }
                 '-' | '_' | ' ' | '.' | '/' => {
                     if !previous_hyphen && !slug.is_empty() {
-                        slug.push('-',);
+                        slug.push('-');
                         previous_hyphen = true;
                     }
                 }
                 _ => {
                     if !previous_hyphen && !slug.is_empty() {
-                        slug.push('-',);
+                        slug.push('-');
                         previous_hyphen = true;
                     }
                 }
             }
         }
 
-        while slug.ends_with('-',) {
+        while slug.ends_with('-') {
             slug.pop();
         }
 
-        if slug.is_empty() {
-            None
-        } else {
-            Some(slug,)
-        }
+        if slug.is_empty() { None } else { Some(slug) }
     }
 }
 
 #[cfg(test)]
-mod tests
-{
+mod tests {
     use proptest::prelude::*;
 
     use super::SlugStrategy;
@@ -101,25 +90,22 @@ mod tests
     }
 
     #[test]
-    fn builder_discards_invalid_and_duplicate_separators()
-    {
-        let slug = SlugStrategy::builder("  Multi--Separator__Value  ",)
+    fn builder_discards_invalid_and_duplicate_separators() {
+        let slug = SlugStrategy::builder("  Multi--Separator__Value  ")
             .build()
-            .expect("expected slug to be derived",);
+            .expect("expected slug to be derived");
         assert_eq!(slug, "multi-separator-value");
     }
 
     #[test]
-    fn builder_returns_none_for_empty_input()
-    {
+    fn builder_returns_none_for_empty_input() {
         assert!(SlugStrategy::builder("   ").build().is_none());
         assert!(SlugStrategy::builder("***").build().is_none());
     }
 
     #[test]
-    fn builder_lowercases_uppercase_characters()
-    {
-        let slug = SlugStrategy::builder("HelloWorld",).build();
+    fn builder_lowercases_uppercase_characters() {
+        let slug = SlugStrategy::builder("HelloWorld").build();
         assert_eq!(slug.as_deref(), Some("helloworld"));
     }
 }


### PR DESCRIPTION
## Summary
- import the module-level default branch constant in the open-source resolver tests to avoid touching private normalizer internals
- run nightly rustfmt, updating formatting across the configuration, normalizer, and slug modules to keep the crate consistent

## Testing
- `cargo +nightly fmt --`
- `cargo +nightly clippy -- -D warnings`
- `cargo +nightly build --all-targets`
- `cargo +nightly test --all`
- `cargo +nightly doc --no-deps`
- `cargo audit`
- `cargo deny check`


------
https://chatgpt.com/codex/tasks/task_e_68e09275f5bc832b98dede3abc05469d