### PR TITLE
64

### DIFF
--- a/imir/src/lib.rs
+++ b/imir/src/lib.rs
@@ -48,7 +48,9 @@ pub use config::{
     BadgeOptions, BadgeStyle, BadgeWidgetAlignment, BadgeWidgetOptions, TargetConfig, TargetEntry,
     TargetKind,
 };
-pub use discover::{DiscoveredRepository, discover_badge_users, discover_stargazer_repositories};
+pub use discover::{
+    DiscoveredRepository, DiscoveryConfig, discover_badge_users, discover_stargazer_repositories,
+};
 pub use error::{Error, io_error};
 pub use normalizer::{
     BadgeDescriptor, BadgeWidgetDescriptor, RenderTarget, TargetsDocument, load_targets,


### PR DESCRIPTION
## Summary
- Added `DiscoveryConfig` struct to make hardcoded constants configurable
- Exposed CLI flags for `--max-pages`, `--badge-pattern`, and `--metrics-pattern`
- Both `discover` and `sync` commands now support custom configuration
- Added 2 new tests for `DiscoveryConfig` (default and custom values)
- All 75 existing tests pass, zero clippy warnings

## Changes
- `discover.rs`: Added `DiscoveryConfig` struct with Default impl
- `main.rs`: Added CLI args for discovery configuration in both discover and sync commands
- `lib.rs`: Exported `DiscoveryConfig` as public API

## Test plan
- [x] All 75 tests passing
- [x] Zero clippy warnings
- [x] Cargo +nightly fmt applied
- [x] Help text verified for both commands
- [x] Custom config values work correctly

Closes part of #64