### PR TITLE
64

### DIFF
--- a/imir/Cargo.toml
+++ b/imir/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 masterror = "0.24"
 octocrab = "0.42"
-tokio = { version = "1.42", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 indicatif = "0.17"

--- a/imir/src/lib.rs
+++ b/imir/src/lib.rs
@@ -40,6 +40,7 @@ mod discover;
 mod error;
 mod normalizer;
 mod open_source;
+pub mod retry;
 mod slug;
 mod sync;
 

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -300,6 +300,7 @@ async fn run_discover(args: DiscoverArgs,) -> Result<(), Error,>
         max_pages:            args.max_pages,
         badge_url_pattern:    args.badge_pattern.clone(),
         metrics_path_pattern: args.metrics_pattern.clone(),
+        ..Default::default()
     };
 
     info!("Starting repository discovery using source: {}", args.source);
@@ -376,6 +377,7 @@ async fn run_sync(args: SyncArgs,) -> Result<(), Error,>
         max_pages:            args.max_pages,
         badge_url_pattern:    args.badge_pattern.clone(),
         metrics_path_pattern: args.metrics_pattern.clone(),
+        ..Default::default()
     };
 
     info!("Starting sync with source: {}", args.source);

--- a/imir/src/retry.rs
+++ b/imir/src/retry.rs
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+/// Retry utilities with exponential backoff for API calls.
+///
+/// Provides helpers for retrying operations with configurable delays and
+/// maximum attempts to handle transient failures gracefully.
+use std::time::Duration;
+
+use masterror::AppError;
+use tokio::time::sleep;
+use tracing::{debug, warn};
+
+/// Configuration for retry behavior with exponential backoff.
+#[derive(Debug, Clone,)]
+pub struct RetryConfig
+{
+    /// Maximum number of retry attempts (default: 3).
+    pub max_attempts:     u32,
+    /// Initial delay between retries in milliseconds (default: 1000).
+    pub initial_delay_ms: u64,
+    /// Multiplier for exponential backoff (default: 2.0).
+    pub backoff_factor:   f64,
+}
+
+impl Default for RetryConfig
+{
+    fn default() -> Self
+    {
+        Self {
+            max_attempts: 3, initial_delay_ms: 1000, backoff_factor: 2.0,
+        }
+    }
+}
+
+/// Executes an async operation with exponential backoff retry logic.
+///
+/// # Arguments
+///
+/// * `config` - Retry configuration (max attempts, delays)
+/// * `operation_name` - Name of the operation for logging
+/// * `f` - Async function to retry
+///
+/// # Errors
+///
+/// Returns the last error encountered if all retry attempts fail.
+///
+/// # Example
+///
+/// ```no_run
+/// use imir::retry::{RetryConfig, retry_with_backoff};
+/// use masterror::AppError;
+///
+/// # async fn example() -> Result<(), AppError> {
+/// let config = RetryConfig::default();
+/// let result = retry_with_backoff(&config, "fetch data", || async {
+///     // Some API call that might fail
+///     Ok::<_, AppError,>(42,)
+/// },)
+/// .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn retry_with_backoff<F, Fut, T,>(
+    config: &RetryConfig,
+    operation_name: &str,
+    mut f: F,
+) -> Result<T, AppError,>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, AppError,>,>,
+{
+    let mut attempt = 1;
+    let mut delay_ms = config.initial_delay_ms;
+
+    loop {
+        match f().await {
+            Ok(result,) => {
+                if attempt > 1 {
+                    debug!("{} succeeded on attempt {}", operation_name, attempt);
+                }
+                return Ok(result,);
+            }
+            Err(error,) => {
+                if attempt >= config.max_attempts {
+                    warn!(
+                        "{} failed after {} attempts: {}",
+                        operation_name, config.max_attempts, error
+                    );
+                    return Err(error,);
+                }
+
+                warn!(
+                    "{} failed on attempt {}/{}: {}. Retrying in {}ms...",
+                    operation_name, attempt, config.max_attempts, error, delay_ms
+                );
+
+                sleep(Duration::from_millis(delay_ms,),).await;
+                delay_ms = (delay_ms as f64 * config.backoff_factor) as u64;
+                attempt += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests
+{
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[test]
+    fn retry_config_default_values()
+    {
+        let config = RetryConfig::default();
+        assert_eq!(config.max_attempts, 3);
+        assert_eq!(config.initial_delay_ms, 1000);
+        assert_eq!(config.backoff_factor, 2.0);
+    }
+
+    #[test]
+    fn retry_config_custom_values()
+    {
+        let config =
+            RetryConfig {
+                max_attempts: 5, initial_delay_ms: 500, backoff_factor: 1.5,
+            };
+        assert_eq!(config.max_attempts, 5);
+        assert_eq!(config.initial_delay_ms, 500);
+        assert_eq!(config.backoff_factor, 1.5);
+    }
+
+    #[tokio::test]
+    async fn retry_succeeds_on_first_attempt()
+    {
+        let config = RetryConfig::default();
+        let result = retry_with_backoff(&config, "test", || async { Ok::<_, AppError,>(42,) },)
+            .await
+            .expect("should succeed",);
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn retry_succeeds_after_failures()
+    {
+        let config =
+            RetryConfig {
+                max_attempts: 3, initial_delay_ms: 10, backoff_factor: 2.0,
+            };
+        let counter = Arc::new(Mutex::new(0,),);
+        let counter_clone = counter.clone();
+
+        let result = retry_with_backoff(&config, "test", move || {
+            let counter = counter_clone.clone();
+            async move {
+                let mut count = counter.lock().unwrap();
+                *count += 1;
+                if *count < 3 { Err(AppError::service("temporary failure",),) } else { Ok(42,) }
+            }
+        },)
+        .await
+        .expect("should succeed after retries",);
+
+        assert_eq!(result, 42);
+        assert_eq!(*counter.lock().unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_fails_after_max_attempts()
+    {
+        let config =
+            RetryConfig {
+                max_attempts: 2, initial_delay_ms: 10, backoff_factor: 2.0,
+            };
+        let counter = Arc::new(Mutex::new(0,),);
+        let counter_clone = counter.clone();
+
+        let result = retry_with_backoff(&config, "test", move || {
+            let counter = counter_clone.clone();
+            async move {
+                let mut count = counter.lock().unwrap();
+                *count += 1;
+                Err::<i32, _,>(AppError::service("persistent failure",),)
+            }
+        },)
+        .await;
+
+        assert!(result.is_err(), "should fail after max attempts",);
+        assert_eq!(*counter.lock().unwrap(), 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented retry mechanism with exponential backoff for all GitHub API calls
- Created `retry` module with `RetryConfig` and `retry_with_backoff` function
- Default retry config: 3 attempts, 1000ms initial delay, 2.0x backoff multiplier
- All API calls (code search, stargazers, user repos) wrapped with retry logic
- Structured logging shows retry attempts and delays (warn/debug levels)
- Added 5 comprehensive tests for retry functionality

## Changes
- `Cargo.toml`: Added `time` feature to tokio
- `retry.rs`: New module with RetryConfig and retry_with_backoff
- `discover.rs`: Integrated retry logic for all GitHub API calls
- `main.rs`: Updated to use default retry config
- `lib.rs`: Exported retry module as public API

## Test plan
- [x] All 80 tests passing (+5 new retry tests)
- [x] Zero clippy warnings
- [x] Cargo +nightly fmt applied
- [x] Retry succeeds on first attempt
- [x] Retry succeeds after temporary failures
- [x] Retry fails after max attempts exhausted
- [x] Config default and custom values validated

## Benefits
- Resilient to transient network failures
- Handles GitHub API rate limit errors gracefully
- Configurable retry behavior per operation
- Clear visibility into retry attempts via structured logging

Closes part of #64