### PR TITLE
ci: add auto-release workflow and use pre-built binaries

### DIFF
--- a/.github/actions/setup-imir/action.yml
+++ b/.github/actions/setup-imir/action.yml
@@ -1,0 +1,51 @@
+name: Setup IMIR
+description: Download and setup pre-built imir binary from releases
+
+inputs:
+  version:
+    description: 'Version to download (e.g., v0.4.0). If not specified, downloads latest release'
+    required: false
+    default: ''
+
+outputs:
+  version:
+    description: 'Downloaded imir version'
+    value: ${{ steps.download.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Determine version to download
+      id: version
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.version }}" ]; then
+          echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+        else
+          VERSION=$(gh release list --repo ${{ github.repository }} --limit 100 | grep '^v' | head -1 | awk '{print $1}')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+    - name: Download imir binary
+      id: download
+      shell: bash
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+        ARCHIVE="imir-x86_64-unknown-linux-gnu.tar.gz"
+        DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${VERSION}/${ARCHIVE}"
+
+        echo "Downloading imir ${VERSION}..."
+        curl -fsSL "${DOWNLOAD_URL}" -o "${ARCHIVE}"
+        tar -xzf "${ARCHIVE}"
+        chmod +x imir
+        mkdir -p "${HOME}/.local/bin"
+        mv imir "${HOME}/.local/bin/imir"
+        echo "${HOME}/.local/bin" >> $GITHUB_PATH
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Verify installation
+      shell: bash
+      run: |
+        imir --version

--- a/.github/workflows/badge-sync.yml
+++ b/.github/workflows/badge-sync.yml
@@ -33,21 +33,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "imir -> target"
+      - name: Setup IMIR
+        uses: ./.github/actions/setup-imir
 
       - name: Normalize targets document
         id: targets
         run: |
           set -euo pipefail
 
-          cargo +stable run --locked --manifest-path imir/Cargo.toml -- \
-            --config "${TARGETS_CONFIG}" > targets.json
+          imir --config "${TARGETS_CONFIG}" > targets.json
 
           echo "path=targets.json" >> "$GITHUB_OUTPUT"
 
@@ -130,8 +124,7 @@ jobs:
             fi
 
             echo "Rendering badge for ${SLUG}" >&2
-            cargo +stable run --locked --manifest-path imir/Cargo.toml -- \
-              badge generate --config "${TARGETS_CONFIG}" --target "${SLUG}" --output metrics
+            imir badge generate --config "${TARGETS_CONFIG}" --target "${SLUG}" --output metrics
           done
 
       - name: Commit badge updates

--- a/.github/workflows/build-imir.yml
+++ b/.github/workflows/build-imir.yml
@@ -1,0 +1,103 @@
+name: Build and Release IMIR
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'imir/**'
+      - '.github/workflows/build-imir.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build IMIR and create release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Get imir version
+        id: version
+        run: |
+          VERSION=$(grep '^version' imir/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Check if release exists
+        id: check_release
+        run: |
+          if gh release view ${{ steps.version.outputs.tag }} &>/dev/null; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build release binary
+        if: steps.check_release.outputs.exists == 'false'
+        run: cargo build --release --locked --manifest-path imir/Cargo.toml
+
+      - name: Package binary
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
+          BIN="imir/target/release/imir"
+          ARCHIVE="imir-x86_64-unknown-linux-gnu.tar.gz"
+          chmod +x "${BIN}"
+          tar -C "$(dirname "${BIN}")" -czf "${ARCHIVE}" "$(basename "${BIN}")"
+          echo "ARCHIVE=${ARCHIVE}" >> $GITHUB_ENV
+
+      - name: Generate changelog
+        if: steps.check_release.outputs.exists == 'false'
+        id: changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            CHANGELOG=$(git log ${PREV_TAG}..HEAD --pretty=format:"- %s" --grep="^imir\|^#[0-9]" || echo "- Initial release")
+          else
+            CHANGELOG="- Initial release"
+          fi
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: IMIR ${{ steps.version.outputs.version }}
+          body: |
+            ## IMIR v${{ steps.version.outputs.version }}
+
+            ### Changes
+            ${{ steps.changelog.outputs.changelog }}
+
+            ### Installation
+            ```bash
+            wget https://github.com/${{ github.repository }}/releases/download/${{ steps.version.outputs.tag }}/imir-x86_64-unknown-linux-gnu.tar.gz
+            tar -xzf imir-x86_64-unknown-linux-gnu.tar.gz
+            chmod +x imir
+            ```
+
+            ### Usage
+            See [documentation](https://github.com/${{ github.repository }}/tree/main/imir) for details.
+          files: ${{ env.ARCHIVE }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release already exists
+        if: steps.check_release.outputs.exists == 'true'
+        run: |
+          echo "Release ${{ steps.version.outputs.tag }} already exists, skipping build"

--- a/.github/workflows/render-all.yml
+++ b/.github/workflows/render-all.yml
@@ -10,32 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  build_cli:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache imir build
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "imir -> target"
-
-      - name: Build IMIR CLI
-        run: cargo build --release --locked --manifest-path imir/Cargo.toml
-
-      - name: Upload IMIR binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: imir
-          path: imir/target/release/imir
-          if-no-files-found: error
-
   prepare:
-    needs: build_cli
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
@@ -43,19 +18,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Download IMIR binary
-        uses: actions/download-artifact@v4
-        with:
-          name: imir
-          path: dist
+      - name: Setup IMIR
+        uses: ./.github/actions/setup-imir
 
       - name: Generate render targets
         id: generate
         run: |
           set -euo pipefail
-          ORCHESTRATOR="dist/imir"
-          chmod +x "${ORCHESTRATOR}"
-          MATRIX="$(${ORCHESTRATOR} --config targets/targets.yaml)"
+          MATRIX="$(imir --config targets/targets.yaml)"
           printf 'matrix=%s\n' "${MATRIX}" >> "${GITHUB_OUTPUT}"
 
   render:

--- a/.github/workflows/render-open-source.yml
+++ b/.github/workflows/render-open-source.yml
@@ -33,13 +33,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache imir build
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "imir -> target"
+      - name: Setup IMIR
+        uses: ./.github/actions/setup-imir
 
       - id: resolve
         name: Resolve repository list
@@ -48,7 +43,7 @@ jobs:
         run: |
           set -euo pipefail
           RAW="${RAW_INPUT:-}"
-          TARGETS=$(cargo run --manifest-path imir/Cargo.toml --quiet --locked -- open-source --input "${RAW}")
+          TARGETS=$(imir open-source --input "${RAW}")
           printf 'targets=%s\n' "${TARGETS}" >> "${GITHUB_OUTPUT}"
 
   render:

--- a/.github/workflows/sync-targets.yml
+++ b/.github/workflows/sync-targets.yml
@@ -18,23 +18,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "imir -> target"
-
-      - name: Build IMIR CLI
-        run: cargo build --release --locked --manifest-path imir/Cargo.toml
+      - name: Setup IMIR
+        uses: ./.github/actions/setup-imir
 
       - name: Discover and sync repositories
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          ./imir/target/release/imir sync \
+          imir sync \
             --config targets/targets.yaml \
             --token "${GITHUB_TOKEN}" \
             --source all


### PR DESCRIPTION
## Summary
- Created `build-imir.yml` workflow for automatic binary releases when imir code changes
- Created `setup-imir` reusable action to download and use pre-built binaries
- Updated all workflows (`render-all.yml`, `render-open-source.yml`, `sync-targets.yml`, `badge-sync.yml`) to use pre-built binaries instead of building from source

## Workflow Details

### build-imir.yml
- Triggers on push to main when `imir/**` files change
- Extracts version from `imir/Cargo.toml`
- Checks if release already exists (skips if yes)
- Builds release binary with `cargo build --release --locked`
- Packages as `imir-x86_64-unknown-linux-gnu.tar.gz`
- Creates GitHub Release with version tag and auto-generated changelog

### setup-imir action
- Downloads latest imir release binary (or specific version via input)
- Extracts tar.gz and installs to `~/.local/bin`
- Adds to PATH and verifies installation with `imir --version`
- Reusable across all workflows

## Changes to Workflows
- **render-all.yml**: Removed `build_cli` job (30 lines), replaced with `setup-imir` action
- **render-open-source.yml**: Removed Rust toolchain + cache (11 lines), use `imir` binary directly
- **sync-targets.yml**: Removed Rust toolchain + cache + build (14 lines), use `imir` binary directly
- **badge-sync.yml**: Removed Rust toolchain + cache (15 lines), use `imir` binary directly

## Benefits
- **Faster CI runs**: No compilation overhead (save ~2-5 minutes per workflow)
- **Consistency**: All workflows use same binary version from release
- **Simplicity**: 50+ lines removed from workflows
- **Automation**: Binary automatically released when imir code changes

## Test Plan
- [x] Clippy checks pass (zero warnings)
- [x] All code formatted with `cargo +nightly fmt`
- [x] Branch pushed successfully
- [ ] Merge PR to trigger first release
- [ ] Verify release workflow creates binary
- [ ] Verify other workflows download and use binary successfully