### PR TITLE
91

### DIFF
--- a/.github/workflows/auto-release-imir.yml
+++ b/.github/workflows/auto-release-imir.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: imir-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -69,6 +73,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add imir/Cargo.toml imir/Cargo.lock
           git commit -m "chore(imir): bump version to ${{ steps.bump.outputs.new_version }}"
+          git pull --rebase origin main
           git push origin HEAD:main
 
       - name: Create GitHub release


### PR DESCRIPTION
Fixed race condition in auto-release workflow.

**Problem:**
Multiple commits to imir/ trigger parallel workflows that:
- Start from same base revision
- Compute same version
- Second push fails with non-fast-forward error

**Solution:**

1. Added concurrency group:
   - Serializes workflow runs
   - Prevents parallel execution
   - Queues runs instead of failing

2. Added git pull --rebase:
   - Fetches latest changes before push
   - Rebases version bump commit
   - Prevents non-fast-forward errors

**Result:**
All commits get releases, no random failures.

Closes #91