### PR TITLE
93

### DIFF
--- a/.github/workflows/auto-release-imir.yml
+++ b/.github/workflows/auto-release-imir.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Sync with latest main
+        run: |
+          git pull --rebase origin main
+
       - name: Get current version
         id: current
         run: |
@@ -73,7 +77,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add imir/Cargo.toml imir/Cargo.lock
           git commit -m "chore(imir): bump version to ${{ steps.bump.outputs.new_version }}"
-          git pull --rebase origin main
           git push origin HEAD:main
 
       - name: Create GitHub release


### PR DESCRIPTION
Fixed version recomputation after rebase.

**Problem:**
Version was computed BEFORE rebase, causing duplicate tag errors:
1. Two runs read old version (1.0.0)
2. Both compute next (1.0.1)
3. First pushes successfully
4. Second rebases - commit dropped as duplicate
5. Second tries to create tag v1.0.1 - fails

**Solution:**
Moved rebase BEFORE version reading:
1. Sync with latest main first
2. Read current version (gets 1.0.1 after rebase)
3. Bump to next version (1.0.2)
4. Push successfully

**Result:**
Sequential runs compute correct incremental versions.
Concurrency group ensures proper serialization.

Closes #93