### PR TITLE
105

### DIFF
--- a/.github/actions/setup-imir/action.yml
+++ b/.github/actions/setup-imir/action.yml
@@ -30,7 +30,7 @@ runs:
         if [ -n "${{ inputs.version }}" ]; then
           echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
         else
-          VERSION=$(gh release list --repo ${{ github.repository }} --limit 100 | grep '^v' | head -1 | awk '{print $1}')
+          VERSION=$(gh release view --repo ${{ github.repository }} --json tagName -q .tagName)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
         fi
       env:


### PR DESCRIPTION
Closes #105

Fixed setup-imir action release version detection that was causing badge-sync workflow failures.

**Problem:**
`gh release list` output format is:
```
TITLE\tLATEST\tTAG\tDATE
IMIR v0.1.5\tLatest\tv0.1.5\t2025-10-10T07:33:56Z
```

Old script used `grep '^v'` but lines start with "IMIR", causing zero matches and script failure.

**Solution:**
Replaced complex parsing with direct API query:
```bash
gh release view --repo ${{ github.repository }} --json tagName -q .tagName
```

**Impact:**
- Fixes badge-sync workflow
- More reliable release version detection
- Simpler code with fewer failure points

**Verification:**
Tested locally:
```bash
$ gh release view --repo RAprogramm/infra-metrics-insight-renderer --json tagName -q .tagName
v0.1.5
```