### PR TITLE
#100 refactor: replace expect with safe error handling in sync.rs

### DIFF
--- a/imir/src/sync.rs
+++ b/imir/src/sync.rs
@@ -45,11 +45,11 @@ pub fn sync_targets(
     discovered: &[DiscoveredRepository]
 ) -> Result<usize, AppError> {
     let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.yellow} [{elapsed_precise}] {msg}")
-            .expect("valid template")
-    );
+    if let Ok(style) = ProgressStyle::default_spinner()
+        .template("{spinner:.yellow} [{elapsed_precise}] {msg}")
+    {
+        pb.set_style(style);
+    }
 
     pb.set_message(format!("Reading config from {}...", config_path.display()));
     debug!("Reading config from {}", config_path.display());


### PR DESCRIPTION
Fixes #100

## Changes
- Replaced `.expect("valid template")` with safe conditional style application in `sync_targets()` function
- Template parsing failure now results in default spinner style instead of panic

## Impact
- Production code in `imir/src/sync.rs` now has zero unsafe unwrap/expect calls
- Progress bar continues to function normally even if template parsing fails

## Testing
- All 164 tests passing
- Zero clippy warnings