### PR TITLE
#102 refactor: replace unwrap/expect with safe error handling

### DIFF
--- a/imir/src/discover.rs
+++ b/imir/src/discover.rs
@@ -185,11 +185,11 @@ pub async fn discover_stargazer_repositories(
     );
 
     let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .template("{spinner:.cyan} [{elapsed_precise}] {msg}")
-            .expect("valid template")
-    );
+    if let Ok(style) = ProgressStyle::default_spinner()
+        .template("{spinner:.cyan} [{elapsed_precise}] {msg}")
+    {
+        pb.set_style(style);
+    }
     pb.set_message("Fetching stargazers...");
 
     let mut discovered = Vec::with_capacity(500);

--- a/imir/src/git.rs
+++ b/imir/src/git.rs
@@ -144,13 +144,17 @@ fn checkout_or_create_branch(branch_name: &str, default_ref: &str) -> Result<(),
             ])
             .output();
 
-        if fetch_result.is_ok() && fetch_result.unwrap().status.success() {
-            run_git(&[
-                "checkout",
-                "-B",
-                branch_name,
-                &format!("origin/{default_ref}")
-            ])?;
+        if let Ok(output) = fetch_result {
+            if output.status.success() {
+                run_git(&[
+                    "checkout",
+                    "-B",
+                    branch_name,
+                    &format!("origin/{default_ref}")
+                ])?;
+            } else {
+                run_git(&["checkout", "-B", branch_name, default_ref])?;
+            }
         } else {
             run_git(&["checkout", "-B", branch_name, default_ref])?;
         }

--- a/imir/src/slugs.rs
+++ b/imir/src/slugs.rs
@@ -89,7 +89,12 @@ pub fn detect_impacted_slugs(
             ])
             .output();
 
-        if fetch_result.is_err() || !fetch_result.unwrap().status.success() {
+        let fetch_failed = match fetch_result {
+            Ok(output) => !output.status.success(),
+            Err(_) => true
+        };
+
+        if fetch_failed {
             return Ok(SlugDetectionResult {
                 slugs:   all_slugs.to_vec(),
                 has_any: !all_slugs.is_empty()


### PR DESCRIPTION
Fixes #102

## Changes
Replaced unsafe unwrap/expect patterns in production code across three modules:

### discover.rs (line 191)
- Replaced `.expect("valid template")` with conditional style application
- Progress bar continues with default style if template parsing fails

### git.rs (line 147)
- Replaced `.unwrap()` after `.is_ok()` check with proper `if let Ok(output)` pattern
- Eliminates potential panic from unsafe unwrap after boolean check

### slugs.rs (line 92)
- Replaced `.unwrap()` in boolean expression with explicit match
- Safely handles both Ok and Err cases without panic risk

## Impact
- Production code in discover.rs, git.rs, and slugs.rs now has zero unsafe unwrap/expect calls
- All error cases handled explicitly with proper fallback behavior

## Testing
- All 164 tests passing
- Zero clippy warnings