### PR TITLE
126

### DIFF
--- a/.github/workflows/badge-sync.yml
+++ b/.github/workflows/badge-sync.yml
@@ -79,13 +79,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          mkdir -p assets/badges/generated
+
           printf '%s' "${SLUGS_JSON}" | jq -r '.[]' | while read -r SLUG; do
             if [ -z "${SLUG}" ]; then
               continue
             fi
 
             echo "Rendering badge for ${SLUG}" >&2
-            imir badge generate --config "${TARGETS_CONFIG}" --target "${SLUG}" --output metrics
+            imir badge generate --config "${TARGETS_CONFIG}" --target "${SLUG}" --output assets/badges/generated
           done
 
       - name: Commit badge updates
@@ -97,7 +99,7 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add metrics
+          git add assets/badges/generated
 
           if git diff --cached --quiet; then
             echo "No badge changes to commit."

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.tmp.svg
 .metrics-tmp/
 
+# Generated badge placeholders (smoke tests only)
+assets/badges/generated/
+
 # Rust build artifacts
 target/
 **/target/


### PR DESCRIPTION
Closes #126

## Problem
`badge-sync.yml` workflow overwrites real metrics (50+ KB SVG from lowlighter/metrics) with lightweight badge placeholders (775 bytes).

Badge placeholders and real metrics shared the same directory (`metrics/`), causing collisions.

## Changes
- Moved badge placeholder generation to `assets/badges/generated/`
- Updated `badge-sync.yml` to use separate output directory
- Added `assets/badges/generated/` to `.gitignore`

## Impact
- ✅ Real metrics preserved in `metrics/` directory
- ✅ Badge placeholders generated in `assets/badges/generated/` (gitignored)
- ✅ ci-check.sh still works (uses temp directory for smoke tests)
- ✅ No more accidental overwrites

## Validation
- ✅ All 172 tests pass
- ✅ Clippy clean
- ✅ Workflow syntax valid