### PR TITLE
165

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+[advisories]
+ignore = [
+    "RUSTSEC-2023-0071",
+]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+* @RAprogramm
+/imir/ @RAprogramm
+/.github/ @RAprogramm
+/targets/ @RAprogramm

--- a/imir/Cargo.lock
+++ b/imir/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -37,9 +37,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -52,44 +52,53 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "async-trait"
@@ -110,9 +119,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base16ct"
@@ -128,9 +137,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -149,9 +158,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -164,32 +173,33 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122ec45a44b270afd1402f351b782c676b173e3c3fb28d86ff7ebfb4d86a4ee4"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -214,9 +224,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.40"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -224,15 +234,15 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -271,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -281,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -293,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -305,27 +315,26 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -361,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
  "alloca",
  "anes",
@@ -386,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -487,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -508,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -557,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -601,14 +610,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -628,15 +637,21 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -649,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -664,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -674,15 +689,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -691,15 +706,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -708,21 +723,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -732,15 +747,14 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -749,27 +763,40 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -785,19 +812,29 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -825,12 +862,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -865,9 +901,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -878,7 +914,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -886,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -896,7 +931,6 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -917,13 +951,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -938,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -962,12 +995,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -975,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -988,11 +1022,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1003,48 +1036,50 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -1059,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1090,19 +1125,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1112,20 +1149,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1138,41 +1165,44 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.2.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76e1c7d7df3e34443b3621b459b066a7b79644f059fc8b2db7070c825fd417e"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
  "ed25519-dalek",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "hmac",
  "js-sys",
  "p256",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
  "sha2",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1185,40 +1215,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.176"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "masterror"
-version = "0.26.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77607e589f49d58c617de7eceea88aa82c1eb4c7f2de71930dbfb228b72bd73a"
+checksum = "2af90a30683338cc4b1808546db9d8da4a9150ffd60f9cb60d1e14abf94feb3d"
 dependencies = [
  "http",
  "itoa",
@@ -1233,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "masterror-derive"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c67cb4a9c7ac7a6473b96e7ed3b72f755809334e1c5c44cf80211358d382d68"
+checksum = "cbaff15e9b083aebe56ef433d7fe166d3e8735a11dfabb2661afb28968ef135c"
 dependencies = [
  "masterror-template",
  "proc-macro2",
@@ -1245,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "masterror-template"
-version = "0.3.8"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cbb19c37caa0e505f0fb43a68184a4d22dc6e81daea40dd00fc24a356ffa9a"
+checksum = "fa90f9eaa68a5c3a60b2322bd19d16ac5cf54e0dba3fdca6cc649fa1317b27d1"
 
 [[package]]
 name = "matchers"
@@ -1260,28 +1296,28 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1305,16 +1341,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1348,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.49.2"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a05f533ce747c92b413d143ae258c3bd11a56ffdf7f2cee1896539c89c59acc"
+checksum = "eb2ad8abffe4e2b05f9cdc7e061de63d305a6dca0af81ca1064a7d98e0b78267"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1359,10 +1395,9 @@ dependencies = [
  "cargo_metadata",
  "cfg-if",
  "chrono",
- "either",
  "futures",
  "futures-util",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "http",
  "http-body",
  "http-body-util",
@@ -1390,15 +1425,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -1408,9 +1443,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "p256"
@@ -1448,12 +1483,12 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1473,18 +1508,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1493,15 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -1554,15 +1583,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1583,6 +1612,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,24 +1632,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -1627,9 +1666,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1641,10 +1680,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1653,12 +1698,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1678,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1687,16 +1732,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1705,14 +1750,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -1730,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1742,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1753,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
@@ -1775,7 +1820,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1783,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",
@@ -1812,22 +1857,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.32"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -1840,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -1852,18 +1897,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1878,9 +1923,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error",
@@ -1890,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1905,11 +1950,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1937,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1950,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1960,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -2000,15 +2045,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -2024,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2094,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -2106,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -2139,12 +2184,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2165,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -2183,9 +2228,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2211,31 +2256,31 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2253,30 +2298,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2284,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2304,23 +2349,23 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2339,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2352,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.7"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2367,33 +2412,33 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.2"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.3"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.3"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2408,21 +2453,21 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2483,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2507,9 +2552,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -2519,9 +2564,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -2530,10 +2575,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unit-prefix"
-version = "0.5.1"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2549,14 +2600,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2573,9 +2625,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2628,28 +2680,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wasip2",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2659,24 +2711,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2684,31 +2722,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.81"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2747,7 +2819,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2758,9 +2830,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2793,24 +2865,24 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -2821,32 +2893,14 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.4",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
@@ -2857,31 +2911,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2891,22 +2928,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2915,22 +2940,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2939,22 +2952,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2963,48 +2964,123 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -3012,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3024,18 +3100,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3044,18 +3120,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,12 +3144,26 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3082,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3093,11 +3183,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/imir/Cargo.lock
+++ b/imir/Cargo.lock
@@ -101,6 +101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +494,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +839,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +888,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hkdf"
@@ -900,6 +953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,9 +968,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1106,6 +1167,7 @@ dependencies = [
 name = "imir"
 version = "0.1.23"
 dependencies = [
+ "base64",
  "clap",
  "criterion",
  "indicatif",
@@ -1117,10 +1179,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]
@@ -1243,6 +1307,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1383,6 +1456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "octocrab"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1562,29 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1774,6 +1880,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +2064,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +2080,18 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sec1"
@@ -2099,6 +2235,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2353,6 +2515,7 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -2974,6 +3137,29 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/imir/Cargo.toml
+++ b/imir/Cargo.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 #
 # SPDX-License-Identifier: MIT
 
@@ -10,22 +10,22 @@ description = "Generate rendering instructions for lowlighter/metrics targets"
 license = "MIT"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive", "env"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+clap = { version = "4", features = ["derive", "env"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_yaml = "0.9"
-masterror = "0.26"
-octocrab = "0.49"
-tokio = { version = "1.48", features = ["rt-multi-thread", "macros", "time"] }
+masterror = "0.27"
+octocrab = "0.51"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 indicatif = "0.18"
-rayon = "1.10"
-regex = "1.12"
+rayon = "1"
+regex = "1"
 
 [dev-dependencies]
-proptest = "1.9"
-tempfile = "3.13"
+proptest = "1"
+tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]

--- a/imir/Cargo.toml
+++ b/imir/Cargo.toml
@@ -27,6 +27,9 @@ regex = "1"
 proptest = "1"
 tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
+wiremock = "0.6"
+serial_test = "3"
+base64 = "0.22"
 
 [[bench]]
 name = "benchmarks"

--- a/imir/benches/benchmarks.rs
+++ b/imir/benches/benchmarks.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::{fmt::Write as _, hint::black_box};
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use imir::parse_targets;
 
 fn benchmark_parse_targets(c: &mut Criterion) {
@@ -56,9 +58,10 @@ targets:
 fn benchmark_large_config_parse(c: &mut Criterion) {
     let mut yaml = String::from("targets:\n");
     for i in 0..100 {
-        yaml.push_str(&format!(
-            "  - owner: user{i}\n    repository: repo{i}\n    type: open_source\n"
-        ));
+        let _ = writeln!(
+            yaml,
+            "  - owner: user{i}\n    repository: repo{i}\n    type: open_source"
+        );
     }
 
     c.bench_function("parse_100_targets", |b| {

--- a/imir/benches/benchmarks.rs
+++ b/imir/benches/benchmarks.rs
@@ -26,7 +26,7 @@ targets:
 ";
 
     c.bench_function("parse_targets_small", |b| {
-        b.iter(|| parse_targets(black_box(yaml)).expect("parse failed"))
+        b.iter(|| parse_targets(black_box(yaml)).expect("parse failed"));
     });
 }
 
@@ -49,7 +49,7 @@ targets:
         b.iter(|| {
             let doc = parse_targets(black_box(yaml)).expect("parse failed");
             black_box(doc.targets.len())
-        })
+        });
     });
 }
 
@@ -62,7 +62,7 @@ fn benchmark_large_config_parse(c: &mut Criterion) {
     }
 
     c.bench_function("parse_100_targets", |b| {
-        b.iter(|| parse_targets(black_box(&yaml)).expect("parse failed"))
+        b.iter(|| parse_targets(black_box(&yaml)).expect("parse failed"));
     });
 }
 
@@ -85,7 +85,7 @@ targets:
 ";
 
     c.bench_function("parse_complex_target", |b| {
-        b.iter(|| parse_targets(black_box(complex_yaml)).expect("parse failed"))
+        b.iter(|| parse_targets(black_box(complex_yaml)).expect("parse failed"));
     });
 }
 

--- a/imir/deny.toml
+++ b/imir/deny.toml
@@ -7,7 +7,9 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-ignore = []
+ignore = [
+    { id = "RUSTSEC-2023-0071", reason = "rsa is pulled in transitively via octocrab -> jsonwebtoken only for GitHub App JWT signing. IMIR authenticates exclusively with personal access tokens, so the vulnerable RSA decryption path is never reached. No fixed upstream release of rsa is available; revisit once octocrab/jsonwebtoken migrate away from the affected version." },
+]
 
 [licenses]
 version = 2

--- a/imir/src/artifact.rs
+++ b/imir/src/artifact.rs
@@ -5,7 +5,10 @@
 ///
 /// Searches multiple candidate locations where lowlighter/metrics may have
 /// written the generated SVG artifact.
-use std::path::{Path, PathBuf};
+use std::{
+    fmt::Write as _,
+    path::{Path, PathBuf}
+};
 
 use masterror::AppError;
 use serde::{Deserialize, Serialize};
@@ -88,7 +91,7 @@ pub fn locate_artifact(
         if let Ok(entries) = std::fs::read_dir(metrics_renders) {
             for entry in entries.flatten() {
                 if let Ok(path) = entry.path().canonicalize() {
-                    error_msg.push_str(&format!("  - {}\n", path.display()));
+                    let _ = writeln!(error_msg, "  - {}", path.display());
                 }
             }
         }

--- a/imir/src/artifact.rs
+++ b/imir/src/artifact.rs
@@ -22,7 +22,7 @@ pub struct ArtifactLocation {
 /// # Arguments
 ///
 /// * `temp_artifact` - Expected filename or relative path
-/// * `workspace` - GitHub workspace directory (usually GITHUB_WORKSPACE)
+/// * `workspace` - GitHub workspace directory (usually `GITHUB_WORKSPACE`)
 ///
 /// # Returns
 ///
@@ -125,7 +125,7 @@ mod tests {
     fn locate_artifact_rejects_empty_temp_artifact() {
         let result = locate_artifact("", "/workspace");
         assert!(result.is_err());
-        let error_msg = format!("{:?}", result.unwrap_err(),);
+        let error_msg = format!("{:?}", result.unwrap_err());
         assert!(error_msg.contains("temp_artifact"),);
     }
 
@@ -133,7 +133,7 @@ mod tests {
     fn locate_artifact_rejects_invalid_filename() {
         let result = locate_artifact("/", "/workspace");
         assert!(result.is_err());
-        let error_msg = format!("{:?}", result.unwrap_err(),);
+        let error_msg = format!("{:?}", result.unwrap_err());
         assert!(error_msg.contains("filename"),);
     }
 }

--- a/imir/src/badge.rs
+++ b/imir/src/badge.rs
@@ -152,16 +152,16 @@ fn build_svg_content(target: &RenderTarget) -> String {
 }
 
 fn badge_label(target: &RenderTarget) -> Cow<'_, str> {
-    match target.repository.as_deref() {
-        Some(repository) => {
+    target.repository.as_deref().map_or_else(
+        || Cow::Borrowed(target.owner.as_str()),
+        |repository| {
             let mut owned = String::with_capacity(target.owner.len() + repository.len() + 1);
             owned.push_str(target.owner.as_str());
             owned.push('/');
             owned.push_str(repository);
             Cow::Owned(owned)
         }
-        None => Cow::Borrowed(target.owner.as_str())
-    }
+    )
 }
 
 fn escape_xml(value: &str) -> Cow<'_, str> {

--- a/imir/src/badge.rs
+++ b/imir/src/badge.rs
@@ -68,8 +68,8 @@ pub fn generate_badge_assets(
 ) -> Result<BadgeAssets, Error> {
     fs::create_dir_all(output_dir).map_err(|source| error::badge_io_error(output_dir, source))?;
 
-    let svg_path = output_dir.join(format!("{}.svg", target.slug,));
-    let manifest_path = output_dir.join(format!("{}.json", target.slug,));
+    let svg_path = output_dir.join(format!("{}.svg", target.slug));
+    let manifest_path = output_dir.join(format!("{}.json", target.slug));
 
     write_svg(&svg_path, target)?;
     write_manifest(&manifest_path, target, &svg_path)?;
@@ -191,7 +191,7 @@ struct BadgeGradient {
     secondary: &'static str
 }
 
-fn badge_background(kind: TargetKind) -> BadgeGradient {
+const fn badge_background(kind: TargetKind) -> BadgeGradient {
     match kind {
         TargetKind::Profile => BadgeGradient {
             primary:   "#6f42c1",
@@ -331,7 +331,7 @@ mod tests {
         let result = escape_xml(input);
         match result {
             Cow::Borrowed(s) => assert_eq!(s, input),
-            Cow::Owned(_) => panic!("expected borrowed variant",)
+            Cow::Owned(_) => panic!("expected borrowed variant")
         }
     }
 
@@ -408,7 +408,7 @@ mod tests {
             svg_path:      PathBuf::from("/tmp/debug.svg"),
             manifest_path: PathBuf::from("/tmp/debug.json")
         };
-        let debug_str = format!("{:?}", assets);
+        let debug_str = format!("{assets:?}");
         assert!(debug_str.contains("BadgeAssets"));
         assert!(debug_str.contains("svg_path"));
     }

--- a/imir/src/config.rs
+++ b/imir/src/config.rs
@@ -126,6 +126,7 @@ impl TargetEntry {
     /// };
     /// assert_eq!(entry.resolved_slug().as_deref(), Some("metrics"));
     /// ```
+    #[must_use] 
     pub fn resolved_slug(&self) -> Option<String> {
         if let Some(custom) = self.slug.as_ref() {
             return SlugStrategy::builder(custom).build();
@@ -147,6 +148,7 @@ impl TargetEntry {
     ///
     /// Leading and trailing whitespace is trimmed. When no override is
     /// supplied, the value falls back to "profile" or the repository name.
+    #[must_use] 
     pub fn resolved_display_name(&self) -> Option<String> {
         if let Some(name) = self.display_name.as_ref() {
             let trimmed = name.trim();

--- a/imir/src/config.rs
+++ b/imir/src/config.rs
@@ -126,7 +126,7 @@ impl TargetEntry {
     /// };
     /// assert_eq!(entry.resolved_slug().as_deref(), Some("metrics"));
     /// ```
-    #[must_use] 
+    #[must_use]
     pub fn resolved_slug(&self) -> Option<String> {
         if let Some(custom) = self.slug.as_ref() {
             return SlugStrategy::builder(custom).build();
@@ -148,7 +148,7 @@ impl TargetEntry {
     ///
     /// Leading and trailing whitespace is trimmed. When no override is
     /// supplied, the value falls back to "profile" or the repository name.
-    #[must_use] 
+    #[must_use]
     pub fn resolved_display_name(&self) -> Option<String> {
         if let Some(name) = self.display_name.as_ref() {
             let trimmed = name.trim();

--- a/imir/src/contributors.rs
+++ b/imir/src/contributors.rs
@@ -233,4 +233,108 @@ mod tests {
 
         assert!(bot_activity.is_bot);
     }
+
+    fn fast_retry() -> RetryConfig {
+        RetryConfig {
+            max_attempts:     1,
+            initial_delay_ms: 0,
+            backoff_factor:   1.0
+        }
+    }
+
+    fn mock_octocrab(server: &wiremock::MockServer) -> Octocrab {
+        Octocrab::builder()
+            .personal_token("test-token")
+            .base_uri(server.uri())
+            .expect("base_uri")
+            .build()
+            .expect("octocrab build")
+    }
+
+    #[tokio::test]
+    async fn fetch_contributor_activity_aggregates_recent_weeks() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path}
+        };
+
+        let server = MockServer::start().await;
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_secs();
+        let recent_week = now_secs.saturating_sub(7 * 86400);
+        let stale_week = now_secs.saturating_sub(60 * 86400);
+        let body = format!(
+            r#"[
+                {{
+                    "author": {{ "login": "alice", "avatar_url": "https://example.com/a.png", "type": "User" }},
+                    "weeks": [
+                        {{ "w": {recent_week}, "a": 100, "d": 20, "c": 5 }},
+                        {{ "w": {stale_week}, "a": 999, "d": 999, "c": 99 }}
+                    ]
+                }},
+                {{
+                    "author": {{ "login": "bot[bot]", "avatar_url": "https://example.com/b.png", "type": "Bot" }},
+                    "weeks": [
+                        {{ "w": {recent_week}, "a": 1, "d": 1, "c": 1 }}
+                    ]
+                }}
+            ]"#
+        );
+        Mock::given(method("GET"))
+            .and(path("/repos/octo/cat/stats/contributors"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(body, "application/json"))
+            .mount(&server)
+            .await;
+
+        let octocrab = mock_octocrab(&server);
+        let activities = fetch_contributor_activity(&octocrab, "octo", "cat", &fast_retry())
+            .await
+            .expect("fetch should succeed");
+
+        assert_eq!(activities.len(), 2);
+        assert_eq!(activities[0].login, "alice");
+        assert_eq!(activities[0].commits, 5);
+        assert_eq!(activities[0].additions, 100);
+        assert!(!activities[0].is_bot);
+        assert_eq!(activities[1].login, "bot[bot]");
+        assert!(activities[1].is_bot);
+    }
+
+    #[tokio::test]
+    async fn fetch_contributor_activity_skips_contributors_without_recent_commits() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path}
+        };
+
+        let server = MockServer::start().await;
+        let stale_week = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_secs()
+            .saturating_sub(120 * 86400);
+        let body = format!(
+            r#"[
+                {{
+                    "author": {{ "login": "ghost", "avatar_url": "https://example.com/g.png", "type": "User" }},
+                    "weeks": [
+                        {{ "w": {stale_week}, "a": 1, "d": 1, "c": 7 }}
+                    ]
+                }}
+            ]"#
+        );
+        Mock::given(method("GET"))
+            .and(path("/repos/octo/cat/stats/contributors"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(body, "application/json"))
+            .mount(&server)
+            .await;
+
+        let octocrab = mock_octocrab(&server);
+        let activities = fetch_contributor_activity(&octocrab, "octo", "cat", &fast_retry())
+            .await
+            .expect("fetch should succeed");
+        assert!(activities.is_empty());
+    }
 }

--- a/imir/src/contributors.rs
+++ b/imir/src/contributors.rs
@@ -125,10 +125,13 @@ pub async fn fetch_contributor_activity(
     )
     .await?;
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|e| AppError::internal(format!("system time error: {e}")))?
-        .as_secs() as i64;
+    let now = i64::try_from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| AppError::internal(format!("system time error: {e}")))?
+            .as_secs()
+    )
+    .unwrap_or(i64::MAX);
 
     let thirty_days_ago = now - (30 * 24 * 60 * 60);
 
@@ -163,7 +166,7 @@ pub async fn fetch_contributor_activity(
         });
     }
 
-    activities.sort_by(|a, b| b.commits.cmp(&a.commits));
+    activities.sort_by_key(|a| std::cmp::Reverse(a.commits));
 
     info!(
         "Found {} active contributors in last 30 days for {}/{}",

--- a/imir/src/contributors.rs
+++ b/imir/src/contributors.rs
@@ -105,7 +105,7 @@ pub async fn fetch_contributor_activity(
 
     let stats: Vec<ContributorStats> = retry_with_backoff(
         retry_config,
-        &format!("contributor stats for {}/{}", owner, repo),
+        &format!("contributor stats for {owner}/{repo}"),
         || {
             let octocrab = octocrab_clone.clone();
             let owner = owner_str.clone();

--- a/imir/src/discover.rs
+++ b/imir/src/discover.rs
@@ -134,16 +134,11 @@ async fn check_repo_has_badge(
     )
     .await;
 
-    match readme_result {
-        Ok(content) => {
-            if let Some(decoded) = content.decoded_content() {
-                Ok(extract_repo_from_readme(&decoded))
-            } else {
-                Ok(None)
-            }
-        }
-        Err(_) => Ok(None)
-    }
+    Ok(readme_result.ok().and_then(|content| {
+        content
+            .decoded_content()
+            .and_then(|decoded| extract_repo_from_readme(&decoded))
+    }))
 }
 
 /// Discovers repositories from users who starred the IMIR repository.

--- a/imir/src/discover.rs
+++ b/imir/src/discover.rs
@@ -656,4 +656,198 @@ More content.
         assert!(!pb.is_finished());
         pb.finish_and_clear();
     }
+
+    fn fast_retry() -> RetryConfig {
+        RetryConfig {
+            max_attempts:     1,
+            initial_delay_ms: 0,
+            backoff_factor:   1.0
+        }
+    }
+
+    fn mock_octocrab(server: &wiremock::MockServer) -> Octocrab {
+        Octocrab::builder()
+            .personal_token("test-token")
+            .base_uri(server.uri())
+            .expect("base_uri")
+            .build()
+            .expect("octocrab build")
+    }
+
+    fn user_json(login: &str) -> String {
+        format!(
+            r#"{{"login":"{login}","id":1,"node_id":"u","avatar_url":"https://example.com/a","gravatar_id":"","url":"https://example.com/u","html_url":"https://example.com/u","followers_url":"https://example.com/x","following_url":"https://example.com/x","gists_url":"https://example.com/x","starred_url":"https://example.com/x","subscriptions_url":"https://example.com/x","organizations_url":"https://example.com/x","repos_url":"https://example.com/x","events_url":"https://example.com/x","received_events_url":"https://example.com/x","type":"User","site_admin":false}}"#
+        )
+    }
+
+    fn repo_json(owner: &str, name: &str, fork: bool) -> String {
+        let user = user_json(owner);
+        format!(
+            r#"{{"id":1,"node_id":"r","name":"{name}","full_name":"{owner}/{name}","private":false,"owner":{user},"html_url":"https://example.com/{owner}/{name}","description":null,"fork":{fork},"url":"https://example.com/{owner}/{name}","archive_url":"https://example.com/x","assignees_url":"https://example.com/x","blobs_url":"https://example.com/x","branches_url":"https://example.com/x","collaborators_url":"https://example.com/x","comments_url":"https://example.com/x","commits_url":"https://example.com/x","compare_url":"https://example.com/x","contents_url":"https://example.com/x","contributors_url":"https://example.com/x","deployments_url":"https://example.com/x","downloads_url":"https://example.com/x","events_url":"https://example.com/x","forks_url":"https://example.com/x","git_commits_url":"https://example.com/x","git_refs_url":"https://example.com/x","git_tags_url":"https://example.com/x","issue_comment_url":"https://example.com/x","issue_events_url":"https://example.com/x","issues_url":"https://example.com/x","keys_url":"https://example.com/x","labels_url":"https://example.com/x","languages_url":"https://example.com/x","merges_url":"https://example.com/x","milestones_url":"https://example.com/x","notifications_url":"https://example.com/x","pulls_url":"https://example.com/x","releases_url":"https://example.com/x","stargazers_url":"https://example.com/x","statuses_url":"https://example.com/x","subscribers_url":"https://example.com/x","subscription_url":"https://example.com/x","tags_url":"https://example.com/x","teams_url":"https://example.com/x","trees_url":"https://example.com/x","hooks_url":"https://example.com/x"}}"#
+        )
+    }
+
+    fn readme_json(content: &str) -> String {
+        use base64::Engine as _;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(content);
+        format!(
+            r#"{{"name":"README.md","path":"README.md","sha":"https://example.com/x","size":{size},"url":"https://example.com/x","html_url":"https://example.com/x","git_url":"https://example.com/x","download_url":"https://example.com/x","type":"file","content":"{encoded}","encoding":"base64","_links":{{"self":"https://example.com/x","git":"https://example.com/x","html":"https://example.com/x"}}}}"#,
+            size = content.len()
+        )
+    }
+
+    #[tokio::test]
+    async fn fetch_stargazers_page_returns_decoded_items() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path}
+        };
+
+        let server = MockServer::start().await;
+        let body = format!(
+            r#"[{{"starred_at":"2026-01-02T00:00:00Z","user":{}}}]"#,
+            user_json("alice")
+        );
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/repos/{IMIR_REPO_OWNER}/{IMIR_REPO_NAME}/stargazers"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(body, "application/json"))
+            .mount(&server)
+            .await;
+
+        let octocrab = mock_octocrab(&server);
+        let page = fetch_stargazers_page(&octocrab, 1, &fast_retry())
+            .await
+            .expect("fetch should succeed");
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(
+            page.items[0].user.as_ref().expect("stargazer user").login,
+            "alice"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_user_repos_first_page_parses_repos() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path}
+        };
+
+        let server = MockServer::start().await;
+        let body = format!("[{}]", repo_json("alice", "demo", false));
+        Mock::given(method("GET"))
+            .and(path("/users/alice/repos"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(body, "application/json"))
+            .mount(&server)
+            .await;
+
+        let octocrab = mock_octocrab(&server);
+        let page = fetch_user_repos_first_page(&octocrab, "alice", &fast_retry())
+            .await
+            .expect("fetch should succeed");
+        assert_eq!(page.items.len(), 1);
+        assert_eq!(page.items[0].name, "demo");
+        assert_eq!(page.items[0].fork, Some(false));
+    }
+
+    #[tokio::test]
+    async fn check_repo_has_badge_returns_some_when_readme_contains_badge() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path}
+        };
+
+        let server = MockServer::start().await;
+        let readme = "[![IMIR](imir-badge-simple-public.svg)]\n![M](metrics/demo.svg)\n";
+        Mock::given(method("GET"))
+            .and(path("/repos/alice/demo/readme/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(readme_json(readme), "application/json")
+            )
+            .mount(&server)
+            .await;
+
+        let octocrab = mock_octocrab(&server);
+        let badge = check_repo_has_badge(&octocrab, "alice", "demo", &fast_retry())
+            .await
+            .expect("fetch should succeed");
+        assert_eq!(badge.as_deref(), Some("demo"));
+    }
+
+    #[tokio::test]
+    async fn check_repo_has_badge_returns_none_when_readme_missing() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path}
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/alice/demo/readme/"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let octocrab = mock_octocrab(&server);
+        let badge = check_repo_has_badge(&octocrab, "alice", "demo", &fast_retry())
+            .await
+            .expect("404 is not an error path");
+        assert!(badge.is_none());
+    }
+
+    #[tokio::test]
+    async fn collect_user_badge_repos_skips_forks_and_records_badged_repos() {
+        use wiremock::{
+            Mock, MockServer, ResponseTemplate,
+            matchers::{method, path}
+        };
+
+        let server = MockServer::start().await;
+        let repos = format!(
+            "[{},{}]",
+            repo_json("alice", "real", false),
+            repo_json("alice", "fork", true)
+        );
+        Mock::given(method("GET"))
+            .and(path("/users/alice/repos"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(repos, "application/json"))
+            .mount(&server)
+            .await;
+
+        let readme = "[![IMIR](imir-badge-simple-public.svg)]\n![M](metrics/real.svg)\n";
+        Mock::given(method("GET"))
+            .and(path("/repos/alice/real/readme/"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(readme_json(readme), "application/json")
+            )
+            .mount(&server)
+            .await;
+
+        let octocrab = mock_octocrab(&server);
+        let config = DiscoveryConfig {
+            max_pages:    1,
+            retry_config: fast_retry()
+        };
+        let pb = stargazer_progress_bar();
+        let mut seen = HashSet::new();
+        let mut discovered = Vec::new();
+        collect_user_badge_repos(
+            &octocrab,
+            "alice",
+            &config,
+            &pb,
+            1,
+            &mut seen,
+            &mut discovered
+        )
+        .await
+        .expect("collect should succeed");
+        pb.finish_and_clear();
+
+        assert_eq!(discovered.len(), 1);
+        assert_eq!(discovered[0].owner, "alice");
+        assert_eq!(discovered[0].repository, "real");
+        assert!(seen.contains(&("alice".to_string(), "real".to_string())));
+    }
 }

--- a/imir/src/discover.rs
+++ b/imir/src/discover.rs
@@ -117,7 +117,7 @@ async fn check_repo_has_badge(
 
     let readme_result = retry_with_backoff(
         retry_config,
-        &format!("README for {}/{}", owner, repo),
+        &format!("README for {owner}/{repo}"),
         || {
             let octocrab = octocrab_clone.clone();
             let owner = owner_str.clone();
@@ -209,7 +209,7 @@ pub async fn discover_stargazer_repositories(
         let octocrab_clone = octocrab.clone();
         let stargazers = retry_with_backoff(
             &config.retry_config,
-            &format!("stargazers page {}", page),
+            &format!("stargazers page {page}"),
             || {
                 let octocrab = octocrab_clone.clone();
                 async move {
@@ -244,10 +244,10 @@ pub async fn discover_stargazer_repositories(
             debug!("Fetching repositories for user: {}", username);
 
             let octocrab_clone = octocrab.clone();
-            let username_clone = username.to_string();
+            let username_clone = username.clone();
             let user_repos = retry_with_backoff(
                 &config.retry_config,
-                &format!("repos for user {}", username),
+                &format!("repos for user {username}"),
                 || {
                     let octocrab = octocrab_clone.clone();
                     let username = username_clone.clone();
@@ -274,7 +274,7 @@ pub async fn discover_stargazer_repositories(
                     continue;
                 }
 
-                let key = (username.to_string(), repo.name.clone());
+                let key = (username.clone(), repo.name.clone());
                 if seen.contains(&key) {
                     continue;
                 }
@@ -289,7 +289,7 @@ pub async fn discover_stargazer_repositories(
                 if has_badge.is_some() {
                     seen.insert(key);
                     let repo_info = DiscoveredRepository {
-                        owner:      username.to_string(),
+                        owner:      username.clone(),
                         repository: repo.name.clone()
                     };
                     debug!("Found IMIR badge in repository: {}", repo_info);
@@ -351,6 +351,7 @@ pub async fn discover_stargazer_repositories(
 /// let repo = extract_repo_from_readme(readme);
 /// assert_eq!(repo, Some("my-repo".to_string()));
 /// ```
+#[must_use] 
 pub fn extract_repo_from_readme(readme_content: &str) -> Option<String> {
     let has_badge = readme_content.contains(BADGE_PUBLIC)
         || readme_content.contains(BADGE_PRIVATE)
@@ -388,36 +389,36 @@ mod tests {
 
     #[test]
     fn extract_repo_from_readme_finds_valid_pattern() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/badge.svg)]
 ![Metrics](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/metrics/test-repo.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("test-repo".to_string()));
     }
 
     #[test]
     fn extract_repo_from_readme_returns_none_without_badge() {
-        let readme = r#"
+        let readme = r"
 ![Metrics](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/metrics/test-repo.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, None);
     }
 
     #[test]
     fn extract_repo_from_readme_returns_none_without_metrics_link() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/badge.svg)]
 Some other content
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, None);
     }
 
     #[test]
     fn extract_repo_from_readme_handles_multiline_content() {
-        let readme = r#"
+        let readme = r"
 # My Project
 
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/badge.svg)]
@@ -427,17 +428,17 @@ Some description here.
 ![Metrics](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/metrics/my-project.svg)
 
 More content.
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("my-project".to_string()));
     }
 
     #[test]
     fn extract_repo_from_readme_rejects_invalid_repo_names() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/badge.svg)]
 ![Metrics](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/metrics/owner/repo.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, None);
     }
@@ -451,72 +452,72 @@ More content.
 
     #[test]
     fn extract_repo_from_readme_finds_first_valid_match() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/badge.svg)]
 ![Metrics](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/metrics/first-repo.svg)
 ![Metrics](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/metrics/second-repo.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("first-repo".to_string()));
     }
 
     #[test]
     fn extract_repo_from_readme_handles_relative_path_dot_slash() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/badge.svg)]
 ![Metrics](./metrics/relative-repo.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("relative-repo".to_string()));
     }
 
     #[test]
     fn extract_repo_from_readme_handles_relative_path_no_prefix() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/badge.svg)]
 ![Metrics](metrics/no-prefix-repo.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("no-prefix-repo".to_string()));
     }
 
     #[test]
     fn extract_repo_from_readme_prefers_dot_slash_over_others() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/badge.svg)]
 ![Metrics](./metrics/dot-slash.svg)
 ![Metrics](metrics/no-prefix.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("dot-slash".to_string()));
     }
 
     #[test]
     fn extract_repo_from_readme_detects_public_badge() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/assets/badges/imir-badge-simple-public.svg)]
 ![Metrics](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/metrics/public-repo.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("public-repo".to_string()));
     }
 
     #[test]
     fn extract_repo_from_readme_detects_private_badge() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/assets/badges/imir-badge-simple-private.svg)]
 ![Metrics](./metrics/private-repo.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("private-repo".to_string()));
     }
 
     #[test]
     fn extract_repo_from_readme_detects_profile_badge() {
-        let readme = r#"
+        let readme = r"
 [![IMIR](https://raw.githubusercontent.com/RAprogramm/infra-metrics-insight-renderer/main/assets/badges/imir-badge-simple-profile.svg)]
 ![Metrics](metrics/profile-metrics.svg)
-"#;
+";
         let result = extract_repo_from_readme(readme);
         assert_eq!(result, Some("profile-metrics".to_string()));
     }
@@ -545,14 +546,14 @@ More content.
     async fn discover_badge_users_fails_with_invalid_token() {
         let config = DiscoveryConfig::default();
         let result = discover_badge_users("invalid_token", &config).await;
-        assert!(result.is_err(), "should fail with invalid token",);
+        assert!(result.is_err(), "should fail with invalid token");
     }
 
     #[tokio::test]
     async fn discover_stargazer_repositories_fails_with_invalid_token() {
         let config = DiscoveryConfig::default();
         let result = discover_stargazer_repositories("invalid_token", &config).await;
-        assert!(result.is_err(), "should fail with invalid token",);
+        assert!(result.is_err(), "should fail with invalid token");
     }
 
     #[test]
@@ -591,7 +592,7 @@ More content.
     #[test]
     fn discovery_config_debug_format() {
         let config = DiscoveryConfig::default();
-        let debug_str = format!("{:?}", config);
+        let debug_str = format!("{config:?}");
         assert!(debug_str.contains("DiscoveryConfig"));
         assert!(debug_str.contains("max_pages"));
     }
@@ -618,7 +619,7 @@ More content.
             owner:      "owner".to_string(),
             repository: "repo".to_string()
         };
-        let debug_str = format!("{:?}", repo);
+        let debug_str = format!("{repo:?}");
         assert!(debug_str.contains("DiscoveredRepository"));
         assert!(debug_str.contains("owner"));
         assert!(debug_str.contains("repository"));

--- a/imir/src/discover.rs
+++ b/imir/src/discover.rs
@@ -187,14 +187,7 @@ pub async fn discover_stargazer_repositories(
         IMIR_REPO_OWNER, IMIR_REPO_NAME
     );
 
-    let pb = ProgressBar::new_spinner();
-    if let Ok(style) =
-        ProgressStyle::default_spinner().template("{spinner:.cyan} [{elapsed_precise}] {msg}")
-    {
-        pb.set_style(style);
-    }
-    pb.set_message("Fetching stargazers...");
-
+    let pb = stargazer_progress_bar();
     let mut discovered = Vec::with_capacity(500);
     let mut seen = HashSet::with_capacity(500);
     let mut page = 1u32;
@@ -206,102 +199,30 @@ pub async fn discover_stargazer_repositories(
         ));
         debug!("Fetching page {} of stargazers", page);
 
-        let octocrab_clone = octocrab.clone();
-        let stargazers = retry_with_backoff(
-            &config.retry_config,
-            &format!("stargazers page {page}"),
-            || {
-                let octocrab = octocrab_clone.clone();
-                async move {
-                    octocrab
-                        .repos(IMIR_REPO_OWNER, IMIR_REPO_NAME)
-                        .list_stargazers()
-                        .per_page(100)
-                        .page(page)
-                        .send()
-                        .await
-                        .map_err(|e| AppError::service(format!("failed to fetch stargazers: {e}")))
-                }
-            }
-        )
-        .await?;
-
+        let stargazers = fetch_stargazers_page(&octocrab, page, &config.retry_config).await?;
         let items_count = stargazers.items.len();
         debug!("Processing {} stargazers on page {}", items_count, page);
 
         for (idx, stargazer) in stargazers.items.iter().enumerate() {
-            let user = match &stargazer.user {
-                Some(u) => u,
-                None => continue
+            let Some(user) = stargazer.user.as_ref() else {
+                continue;
             };
-            let username = &user.login;
             pb.set_message(format!(
                 "Processing stargazer {}/{} on page {}...",
                 idx + 1,
                 items_count,
                 page
             ));
-            debug!("Fetching repositories for user: {}", username);
-
-            let octocrab_clone = octocrab.clone();
-            let username_clone = username.clone();
-            let user_repos = retry_with_backoff(
-                &config.retry_config,
-                &format!("repos for user {username}"),
-                || {
-                    let octocrab = octocrab_clone.clone();
-                    let username = username_clone.clone();
-                    async move {
-                        octocrab
-                            .users(&username)
-                            .repos()
-                            .per_page(100)
-                            .page(1u32)
-                            .send()
-                            .await
-                            .map_err(|e| {
-                                AppError::service(format!(
-                                    "failed to fetch repos for {username}: {e}"
-                                ))
-                            })
-                    }
-                }
+            collect_user_badge_repos(
+                &octocrab,
+                &user.login,
+                config,
+                &pb,
+                page,
+                &mut seen,
+                &mut discovered
             )
             .await?;
-
-            for repo in &user_repos.items {
-                if repo.fork.unwrap_or(false) {
-                    continue;
-                }
-
-                let key = (username.clone(), repo.name.clone());
-                if seen.contains(&key) {
-                    continue;
-                }
-
-                pb.set_message(format!("Checking README in {}/{}...", username, repo.name));
-                debug!("Checking README in {}/{}", username, repo.name);
-
-                let has_badge =
-                    check_repo_has_badge(&octocrab, username, &repo.name, &config.retry_config)
-                        .await?;
-
-                if has_badge.is_some() {
-                    seen.insert(key);
-                    let repo_info = DiscoveredRepository {
-                        owner:      username.clone(),
-                        repository: repo.name.clone()
-                    };
-                    debug!("Found IMIR badge in repository: {}", repo_info);
-                    discovered.push(repo_info);
-                    pb.set_message(format!(
-                        "Found {} repositories with badge (page {}/{})...",
-                        discovered.len(),
-                        page,
-                        config.max_pages
-                    ));
-                }
-            }
         }
 
         if items_count == 0 || page >= config.max_pages {
@@ -320,6 +241,117 @@ pub async fn discover_stargazer_repositories(
         discovered.len()
     );
     Ok(discovered)
+}
+
+/// Builds the spinner-style [`ProgressBar`] used by stargazer discovery.
+fn stargazer_progress_bar() -> ProgressBar {
+    let pb = ProgressBar::new_spinner();
+    if let Ok(style) =
+        ProgressStyle::default_spinner().template("{spinner:.cyan} [{elapsed_precise}] {msg}")
+    {
+        pb.set_style(style);
+    }
+    pb.set_message("Fetching stargazers...");
+    pb
+}
+
+/// Fetches one page of stargazers for the IMIR repository.
+async fn fetch_stargazers_page(
+    octocrab: &Octocrab,
+    page: u32,
+    retry_config: &RetryConfig
+) -> Result<octocrab::Page<octocrab::models::StarGazer>, AppError> {
+    let octocrab_clone = octocrab.clone();
+    retry_with_backoff(retry_config, &format!("stargazers page {page}"), || {
+        let octocrab = octocrab_clone.clone();
+        async move {
+            octocrab
+                .repos(IMIR_REPO_OWNER, IMIR_REPO_NAME)
+                .list_stargazers()
+                .per_page(100)
+                .page(page)
+                .send()
+                .await
+                .map_err(|e| AppError::service(format!("failed to fetch stargazers: {e}")))
+        }
+    })
+    .await
+}
+
+/// Fetches the first page of repositories owned by the given user.
+async fn fetch_user_repos_first_page(
+    octocrab: &Octocrab,
+    username: &str,
+    retry_config: &RetryConfig
+) -> Result<octocrab::Page<octocrab::models::Repository>, AppError> {
+    let octocrab_clone = octocrab.clone();
+    let username_owned = username.to_owned();
+    retry_with_backoff(retry_config, &format!("repos for user {username}"), || {
+        let octocrab = octocrab_clone.clone();
+        let username = username_owned.clone();
+        async move {
+            octocrab
+                .users(&username)
+                .repos()
+                .per_page(100)
+                .page(1u32)
+                .send()
+                .await
+                .map_err(|e| {
+                    AppError::service(format!("failed to fetch repos for {username}: {e}"))
+                })
+        }
+    })
+    .await
+}
+
+/// Scans a single user's repositories for IMIR badges, appending matches to
+/// `discovered` and remembering them in `seen` to suppress duplicates.
+async fn collect_user_badge_repos(
+    octocrab: &Octocrab,
+    username: &str,
+    config: &DiscoveryConfig,
+    pb: &ProgressBar,
+    page: u32,
+    seen: &mut HashSet<(String, String)>,
+    discovered: &mut Vec<DiscoveredRepository>
+) -> Result<(), AppError> {
+    debug!("Fetching repositories for user: {}", username);
+    let user_repos = fetch_user_repos_first_page(octocrab, username, &config.retry_config).await?;
+
+    for repo in &user_repos.items {
+        if repo.fork.unwrap_or(false) {
+            continue;
+        }
+
+        let key = (username.to_owned(), repo.name.clone());
+        if seen.contains(&key) {
+            continue;
+        }
+
+        pb.set_message(format!("Checking README in {}/{}...", username, repo.name));
+        debug!("Checking README in {}/{}", username, repo.name);
+
+        let has_badge =
+            check_repo_has_badge(octocrab, username, &repo.name, &config.retry_config).await?;
+
+        if has_badge.is_some() {
+            seen.insert(key);
+            let repo_info = DiscoveredRepository {
+                owner:      username.to_owned(),
+                repository: repo.name.clone()
+            };
+            debug!("Found IMIR badge in repository: {}", repo_info);
+            discovered.push(repo_info);
+            pb.set_message(format!(
+                "Found {} repositories with badge (page {}/{})...",
+                discovered.len(),
+                page,
+                config.max_pages
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Extracts repository owner and name from README content.

--- a/imir/src/discover.rs
+++ b/imir/src/discover.rs
@@ -115,10 +115,8 @@ async fn check_repo_has_badge(
     let owner_str = owner.to_string();
     let repo_str = repo.to_string();
 
-    let readme_result = retry_with_backoff(
-        retry_config,
-        &format!("README for {owner}/{repo}"),
-        || {
+    let readme_result =
+        retry_with_backoff(retry_config, &format!("README for {owner}/{repo}"), || {
             let octocrab = octocrab_clone.clone();
             let owner = owner_str.clone();
             let repo = repo_str.clone();
@@ -130,9 +128,8 @@ async fn check_repo_has_badge(
                     .await
                     .map_err(|e| AppError::service(format!("failed to fetch README: {e}")))
             }
-        }
-    )
-    .await;
+        })
+        .await;
 
     Ok(readme_result.ok().and_then(|content| {
         content
@@ -378,7 +375,7 @@ async fn collect_user_badge_repos(
 /// let repo = extract_repo_from_readme(readme);
 /// assert_eq!(repo, Some("my-repo".to_string()));
 /// ```
-#[must_use] 
+#[must_use]
 pub fn extract_repo_from_readme(readme_content: &str) -> Option<String> {
     let has_badge = readme_content.contains(BADGE_PUBLIC)
         || readme_content.contains(BADGE_PRIVATE)

--- a/imir/src/discover.rs
+++ b/imir/src/discover.rs
@@ -648,4 +648,12 @@ More content.
         assert!(debug_str.contains("owner"));
         assert!(debug_str.contains("repository"));
     }
+
+    #[test]
+    fn stargazer_progress_bar_initialises_with_fetching_message() {
+        let pb = stargazer_progress_bar();
+        assert_eq!(pb.message(), "Fetching stargazers...");
+        assert!(!pb.is_finished());
+        pb.finish_and_clear();
+    }
 }

--- a/imir/src/error.rs
+++ b/imir/src/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     /// Wraps YAML decoding errors.
     #[error("failed to parse configuration: {source}")]
     Parse {
-        /// Source decoding error from serde_yaml.
+        /// Source decoding error from `serde_yaml`.
         source: serde_yaml::Error
     },
     /// Returned when the configuration violates invariants.
@@ -109,6 +109,7 @@ impl Error {
     /// This method is primarily intended for CLI contexts where the variant
     /// name does not add value to end users. The returned string matches the
     /// [`std::fmt::Display`] implementation.
+    #[must_use] 
     pub fn to_display_string(&self) -> String {
         format!("{self}")
     }
@@ -144,6 +145,7 @@ impl From<masterror::AppError> for Error {
 ///
 /// * `path` - Location of the configuration file that triggered the error.
 /// * `source` - I/O error reported by the operating system.
+#[must_use] 
 pub fn io_error(path: &Path, source: std::io::Error) -> Error {
     Error::Io {
         path: path.to_path_buf(),

--- a/imir/src/error.rs
+++ b/imir/src/error.rs
@@ -109,7 +109,7 @@ impl Error {
     /// This method is primarily intended for CLI contexts where the variant
     /// name does not add value to end users. The returned string matches the
     /// [`std::fmt::Display`] implementation.
-    #[must_use] 
+    #[must_use]
     pub fn to_display_string(&self) -> String {
         format!("{self}")
     }
@@ -145,7 +145,7 @@ impl From<masterror::AppError> for Error {
 ///
 /// * `path` - Location of the configuration file that triggered the error.
 /// * `source` - I/O error reported by the operating system.
-#[must_use] 
+#[must_use]
 pub fn io_error(path: &Path, source: std::io::Error) -> Error {
     Error::Io {
         path: path.to_path_buf(),

--- a/imir/src/file.rs
+++ b/imir/src/file.rs
@@ -73,11 +73,11 @@ pub fn move_file(source: &str, destination: &str) -> Result<FileMoveResult, AppE
     }
 
     std::fs::copy(source_path, dest_path).map_err(|e| {
-        AppError::service(format!("failed to copy {} to {}: {e}", source, destination))
+        AppError::service(format!("failed to copy {source} to {destination}: {e}"))
     })?;
 
     std::fs::remove_file(source_path)
-        .map_err(|e| AppError::service(format!("failed to remove source file {}: {e}", source)))?;
+        .map_err(|e| AppError::service(format!("failed to remove source file {source}: {e}")))?;
 
     Ok(FileMoveResult {
         destination: dest_path.to_path_buf(),
@@ -119,7 +119,7 @@ mod tests {
     fn move_file_rejects_nonexistent_source() {
         let result = move_file("/nonexistent/file.svg", "/tmp/dest.svg");
         assert!(result.is_err());
-        let error_msg = format!("{:?}", result.unwrap_err(),);
+        let error_msg = format!("{:?}", result.unwrap_err());
         assert!(error_msg.contains("source file not found"),);
     }
 
@@ -128,7 +128,7 @@ mod tests {
         let dir = tempdir().expect("failed to create tempdir");
         let result = move_file(dir.path().to_str().unwrap(), "/tmp/dest.svg");
         assert!(result.is_err());
-        let error_msg = format!("{:?}", result.unwrap_err(),);
+        let error_msg = format!("{:?}", result.unwrap_err());
         assert!(error_msg.contains("not a file"),);
     }
 

--- a/imir/src/gh.rs
+++ b/imir/src/gh.rs
@@ -177,7 +177,7 @@ fn create_pr(
         .flat_map(|label| vec!["--label".to_string(), (*label).to_string()])
         .collect();
 
-    let label_arg_refs: Vec<&str> = label_args.iter().map(|s| s.as_str()).collect();
+    let label_arg_refs: Vec<&str> = label_args.iter().map(std::string::String::as_str).collect();
     args.extend(label_arg_refs);
 
     let output = Command::new("gh")

--- a/imir/src/git.rs
+++ b/imir/src/git.rs
@@ -322,4 +322,80 @@ mod tests {
         assert_eq!(result.pushed, cloned.pushed);
         assert_eq!(result.default_base, cloned.default_base);
     }
+
+    fn make_test_repo() -> (tempfile::TempDir, tempfile::TempDir) {
+        let upstream = tempfile::tempdir().expect("upstream tempdir");
+        let local = tempfile::tempdir().expect("local tempdir");
+
+        Command::new("git")
+            .args(["init", "--quiet", "--bare", "--initial-branch=main"])
+            .current_dir(upstream.path())
+            .status()
+            .expect("git init --bare");
+
+        Command::new("git")
+            .args(["init", "--quiet", "--initial-branch=main"])
+            .current_dir(local.path())
+            .status()
+            .expect("git init");
+
+        let upstream_url = upstream.path().to_str().expect("utf8 upstream path");
+        for args in [
+            ["config", "user.name", "Test"].as_slice(),
+            ["config", "user.email", "test@example.com"].as_slice(),
+            ["config", "commit.gpgsign", "false"].as_slice(),
+            ["remote", "add", "origin", upstream_url].as_slice()
+        ] {
+            Command::new("git")
+                .args(args)
+                .current_dir(local.path())
+                .status()
+                .expect("git config/remote");
+        }
+
+        std::fs::write(local.path().join("seed.txt"), "seed\n").expect("write seed");
+        for args in [
+            ["add", "seed.txt"].as_slice(),
+            ["commit", "--quiet", "-m", "seed"].as_slice(),
+            ["push", "--quiet", "-u", "origin", "main"].as_slice()
+        ] {
+            Command::new("git")
+                .args(args)
+                .current_dir(local.path())
+                .status()
+                .expect("git add/commit/push");
+        }
+
+        (upstream, local)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn git_commit_push_creates_branch_and_pushes_changes() {
+        let (_upstream, local) = make_test_repo();
+        let prev_cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(local.path()).expect("cd local");
+
+        std::fs::write(local.path().join("metrics.svg"), "<svg/>\n").expect("write metrics");
+        let result = git_commit_push("ci/metrics-refresh-demo", "metrics.svg", "chore: refresh");
+
+        std::env::set_current_dir(&prev_cwd).expect("restore cwd");
+        let result = result.expect("commit+push should succeed");
+        assert!(result.pushed);
+        assert!(!result.default_base.is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn git_commit_push_returns_unpushed_when_no_changes() {
+        let (_upstream, local) = make_test_repo();
+        let prev_cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(local.path()).expect("cd local");
+
+        let result = git_commit_push("ci/metrics-refresh-noop", "seed.txt", "chore: noop");
+
+        std::env::set_current_dir(&prev_cwd).expect("restore cwd");
+        let result = result.expect("no-op invocation should not error");
+        assert!(!result.pushed);
+    }
 }

--- a/imir/src/git.rs
+++ b/imir/src/git.rs
@@ -195,10 +195,7 @@ fn commit_changes(message: &str) -> Result<(), AppError> {
     run_git(&["commit", "-m", message])
 }
 
-fn push_with_retry(
-    branch_name: &str,
-    upstream_before: Option<&String>
-) -> Result<bool, AppError> {
+fn push_with_retry(branch_name: &str, upstream_before: Option<&String>) -> Result<bool, AppError> {
     for attempt in 1..=3 {
         if try_push(branch_name)? {
             return Ok(true);
@@ -244,10 +241,7 @@ fn try_push(branch_name: &str) -> Result<bool, AppError> {
     Ok(output.status.success())
 }
 
-fn try_force_push(
-    branch_name: &str,
-    upstream_before: Option<&String>
-) -> Result<bool, AppError> {
+fn try_force_push(branch_name: &str, upstream_before: Option<&String>) -> Result<bool, AppError> {
     let force_arg = upstream_before.map_or_else(
         || "--force-with-lease".to_string(),
         |sha| format!("--force-with-lease=refs/heads/{branch_name}:{sha}")

--- a/imir/src/git.rs
+++ b/imir/src/git.rs
@@ -114,8 +114,7 @@ fn checkout_or_create_branch(branch_name: &str, default_ref: &str) -> Result<(),
     let remote_exists = Command::new("git")
         .args(["ls-remote", "--exit-code", "--heads", "origin", branch_name])
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+        .is_ok_and(|o| o.status.success());
 
     if remote_exists {
         run_git(&[

--- a/imir/src/git.rs
+++ b/imir/src/git.rs
@@ -75,7 +75,7 @@ pub fn git_commit_push(
 
     commit_changes(commit_message)?;
 
-    let pushed = push_with_retry(branch_name, &upstream_before)?;
+    let pushed = push_with_retry(branch_name, upstream_before.as_ref())?;
 
     Ok(GitPushResult {
         pushed,
@@ -195,7 +195,10 @@ fn commit_changes(message: &str) -> Result<(), AppError> {
     run_git(&["commit", "-m", message])
 }
 
-fn push_with_retry(branch_name: &str, upstream_before: &Option<String>) -> Result<bool, AppError> {
+fn push_with_retry(
+    branch_name: &str,
+    upstream_before: Option<&String>
+) -> Result<bool, AppError> {
     for attempt in 1..=3 {
         if try_push(branch_name)? {
             return Ok(true);
@@ -216,7 +219,7 @@ fn push_with_retry(branch_name: &str, upstream_before: &Option<String>) -> Resul
 
         let remote_after = get_upstream_sha(branch_name)?;
 
-        if upstream_before.is_some() && remote_after != *upstream_before {
+        if upstream_before.is_some() && remote_after.as_ref() != upstream_before {
             continue;
         }
 
@@ -241,12 +244,14 @@ fn try_push(branch_name: &str) -> Result<bool, AppError> {
     Ok(output.status.success())
 }
 
-fn try_force_push(branch_name: &str, upstream_before: &Option<String>) -> Result<bool, AppError> {
-    let force_arg = if let Some(sha) = upstream_before {
-        format!("--force-with-lease=refs/heads/{branch_name}:{sha}")
-    } else {
-        "--force-with-lease".to_string()
-    };
+fn try_force_push(
+    branch_name: &str,
+    upstream_before: Option<&String>
+) -> Result<bool, AppError> {
+    let force_arg = upstream_before.map_or_else(
+        || "--force-with-lease".to_string(),
+        |sha| format!("--force-with-lease=refs/heads/{branch_name}:{sha}")
+    );
 
     let output = Command::new("git")
         .args(["push", &force_arg, "origin", branch_name])

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -222,7 +222,7 @@ struct SlugsArgs {
     #[arg(long = "config", value_name = "PATH")]
     config: PathBuf,
 
-    /// Event name (schedule, push, pull_request).
+    /// Event name (schedule, push, `pull_request`).
     #[arg(long = "event", value_name = "EVENT")]
     event: Option<String>
 }
@@ -567,7 +567,7 @@ fn run_badge_generate_all(args: BadgeGenerateAllArgs) -> Result<(), Error> {
     let mut failed_targets = Vec::new();
     for result in results {
         if let Err(e) = result {
-            eprintln!("Failed to generate badge: {}", e);
+            eprintln!("Failed to generate badge: {e}");
             error_count += 1;
             failed_targets.push(e.to_string());
         }
@@ -575,8 +575,7 @@ fn run_badge_generate_all(args: BadgeGenerateAllArgs) -> Result<(), Error> {
 
     if error_count > 0 {
         return Err(Error::validation(format!(
-            "{} badge(s) failed to generate",
-            error_count
+            "{error_count} badge(s) failed to generate"
         )));
     }
 
@@ -744,7 +743,7 @@ fn run_slugs(args: SlugsArgs) -> Result<(), Error> {
     let document = load_targets(&args.config)?;
     let all_slugs: Vec<String> = document.targets.iter().map(|t| t.slug.clone()).collect();
 
-    let files: Vec<&str> = args.files.iter().map(|s| s.as_str()).collect();
+    let files: Vec<&str> = args.files.iter().map(std::string::String::as_str).collect();
 
     let base_ref = if args.event == Some("schedule".to_string()) {
         ""
@@ -826,7 +825,7 @@ fn run_gh(args: GhArgs) -> Result<(), Error> {
                 pr_args.repo, pr_args.head, pr_args.base
             );
 
-            let label_refs: Vec<&str> = pr_args.labels.iter().map(|s| s.as_str()).collect();
+            let label_refs: Vec<&str> = pr_args.labels.iter().map(std::string::String::as_str).collect();
 
             let result = gh_pr_create(
                 &pr_args.repo,
@@ -1131,7 +1130,7 @@ targets:
         };
 
         let result = super::run_targets(args);
-        assert!(result.is_err(), "should fail for missing file",);
+        assert!(result.is_err(), "should fail for missing file");
     }
 
     #[test]
@@ -1154,7 +1153,7 @@ targets:
         };
 
         let result = super::run_targets(args);
-        assert!(result.is_err(), "should fail for invalid YAML",);
+        assert!(result.is_err(), "should fail for invalid YAML");
     }
 
     #[test]

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -446,15 +446,15 @@ async fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Command::Targets(args)) => run_targets(args),
-        Some(Command::OpenSource(args)) => run_open_source(args),
+        Some(Command::Targets(args)) => run_targets(&args),
+        Some(Command::OpenSource(args)) => run_open_source(&args),
         Some(Command::Badge(args)) => run_badge(args),
         Some(Command::Discover(args)) => run_discover(args).await,
         Some(Command::Sync(args)) => run_sync(args).await,
-        Some(Command::Readme(args)) => run_readme(args),
+        Some(Command::Readme(args)) => run_readme(&args),
         Some(Command::Contributors(args)) => run_contributors(args).await,
-        Some(Command::Slugs(args)) => run_slugs(args),
-        Some(Command::Artifact(args)) => run_artifact(args),
+        Some(Command::Slugs(args)) => run_slugs(&args),
+        Some(Command::Artifact(args)) => run_artifact(&args),
         Some(Command::File(args)) => run_file(args),
         Some(Command::Git(args)) => run_git(args),
         Some(Command::Gh(args)) => run_gh(args),
@@ -464,7 +464,7 @@ async fn run() -> Result<(), Error> {
     }
 }
 
-fn run_targets(args: TargetsArgs) -> Result<(), Error> {
+fn run_targets(args: &TargetsArgs) -> Result<(), Error> {
     run_targets_from_path(&args.config, args.pretty)
 }
 
@@ -497,7 +497,7 @@ fn write_targets_document<W: io::Write>(
 ///
 /// Returns an [`Error`] when repository inputs are invalid or serialization
 /// fails.
-fn run_open_source(args: OpenSourceArgs) -> Result<(), Error> {
+fn run_open_source(args: &OpenSourceArgs) -> Result<(), Error> {
     let trimmed = args
         .input
         .as_deref()
@@ -524,12 +524,12 @@ fn run_legacy_targets(args: &LegacyTargetsArgs) -> Result<(), Error> {
 
 fn run_badge(args: BadgeArgs) -> Result<(), Error> {
     match args.command {
-        BadgeCommand::Generate(arguments) => run_badge_generate(arguments),
-        BadgeCommand::GenerateAll(arguments) => run_badge_generate_all(arguments)
+        BadgeCommand::Generate(arguments) => run_badge_generate(&arguments),
+        BadgeCommand::GenerateAll(arguments) => run_badge_generate_all(&arguments)
     }
 }
 
-fn run_badge_generate(args: BadgeGenerateArgs) -> Result<(), Error> {
+fn run_badge_generate(args: &BadgeGenerateArgs) -> Result<(), Error> {
     let document = load_targets(&args.config)?;
     let target = document
         .targets
@@ -542,7 +542,7 @@ fn run_badge_generate(args: BadgeGenerateArgs) -> Result<(), Error> {
     Ok(())
 }
 
-fn run_badge_generate_all(args: BadgeGenerateAllArgs) -> Result<(), Error> {
+fn run_badge_generate_all(args: &BadgeGenerateAllArgs) -> Result<(), Error> {
     use rayon::prelude::*;
     use tracing::{debug, info};
 
@@ -693,7 +693,7 @@ async fn run_sync(args: SyncArgs) -> Result<(), Error> {
     Ok(())
 }
 
-fn run_readme(args: ReadmeArgs) -> Result<(), Error> {
+fn run_readme(args: &ReadmeArgs) -> Result<(), Error> {
     use imir::update_readme;
 
     info!("Loading targets from {}", args.config.display());
@@ -732,7 +732,7 @@ async fn run_contributors(args: ContributorsArgs) -> Result<(), Error> {
     Ok(())
 }
 
-fn run_slugs(args: SlugsArgs) -> Result<(), Error> {
+fn run_slugs(args: &SlugsArgs) -> Result<(), Error> {
     info!(
         "Detecting impacted slugs: base={}, head={}, files={:?}",
         args.base_ref, args.head_ref, args.files
@@ -759,7 +759,7 @@ fn run_slugs(args: SlugsArgs) -> Result<(), Error> {
     Ok(())
 }
 
-fn run_artifact(args: ArtifactArgs) -> Result<(), Error> {
+fn run_artifact(args: &ArtifactArgs) -> Result<(), Error> {
     info!(
         "Locating artifact: temp={}, workspace={}",
         args.temp_artifact, args.workspace
@@ -1127,7 +1127,7 @@ targets:
             other => panic!("unexpected command variant: {other:?}")
         };
 
-        let result = super::run_targets(args);
+        let result = super::run_targets(&args);
         assert!(result.is_err(), "should fail for missing file");
     }
 
@@ -1150,7 +1150,7 @@ targets:
             other => panic!("unexpected command variant: {other:?}")
         };
 
-        let result = super::run_targets(args);
+        let result = super::run_targets(&args);
         assert!(result.is_err(), "should fail for invalid YAML");
     }
 

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -823,7 +823,11 @@ fn run_gh(args: GhArgs) -> Result<(), Error> {
                 pr_args.repo, pr_args.head, pr_args.base
             );
 
-            let label_refs: Vec<&str> = pr_args.labels.iter().map(std::string::String::as_str).collect();
+            let label_refs: Vec<&str> = pr_args
+                .labels
+                .iter()
+                .map(std::string::String::as_str)
+                .collect();
 
             let result = gh_pr_create(
                 &pr_args.repo,

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -1042,6 +1042,95 @@ targets:
     }
 
     #[test]
+    fn badge_generate_all_writes_assets_for_every_target() {
+        let temp = tempdir().expect("failed to create tempdir");
+        let config_path = temp.path().join("targets.yaml");
+        let output_dir = temp.path().join("artifacts");
+        let yaml = r"
+targets:
+  - owner: example
+    repository: alpha
+    type: open_source
+    slug: example-alpha
+  - owner: example
+    repository: beta
+    type: open_source
+    slug: example-beta
+";
+        fs::write(&config_path, yaml).expect("failed to write config");
+
+        let cli = Cli::try_parse_from([
+            env!("CARGO_PKG_NAME"),
+            "badge",
+            "generate-all",
+            "--config",
+            config_path.to_str().expect("utf8"),
+            "--output",
+            output_dir.to_str().expect("utf8")
+        ])
+        .expect("failed to parse badge generate-all command");
+
+        let args = match cli.command.expect("missing command") {
+            Command::Badge(arguments) => arguments,
+            other => panic!("unexpected command variant: {other:?}")
+        };
+
+        run_badge(args).expect("batch badge generation failed");
+
+        for slug in ["example-alpha", "example-beta"] {
+            assert!(output_dir.join(format!("{slug}.svg")).exists());
+            assert!(output_dir.join(format!("{slug}.json")).exists());
+        }
+    }
+
+    #[test]
+    fn badge_generate_all_reports_failed_slugs_in_error() {
+        let temp = tempdir().expect("failed to create tempdir");
+        let config_path = temp.path().join("targets.yaml");
+        let blocker_path = temp.path().join("blocker");
+        fs::write(&blocker_path, "occupied").expect("failed to write blocker");
+
+        let yaml = r"
+targets:
+  - owner: example
+    repository: alpha
+    type: open_source
+    slug: example-alpha
+";
+        fs::write(&config_path, yaml).expect("failed to write config");
+
+        let cli = Cli::try_parse_from([
+            env!("CARGO_PKG_NAME"),
+            "badge",
+            "generate-all",
+            "--config",
+            config_path.to_str().expect("utf8"),
+            "--output",
+            blocker_path.to_str().expect("utf8")
+        ])
+        .expect("failed to parse badge generate-all command");
+
+        let args = match cli.command.expect("missing command") {
+            Command::Badge(arguments) => arguments,
+            other => panic!("unexpected command variant: {other:?}")
+        };
+
+        let error = run_badge(args).expect_err("expected batch failure");
+        match error {
+            imir::Error::Validation {
+                message
+            } => {
+                assert!(
+                    message.contains("example-alpha"),
+                    "error must name the failing slug, got: {message}"
+                );
+                assert!(message.contains("1 badge(s) failed to generate"));
+            }
+            other => panic!("unexpected error variant: {other:?}")
+        }
+    }
+
+    #[test]
     fn badge_generate_reports_missing_target() {
         let temp = tempdir().expect("failed to create tempdir");
         let config_path = temp.path().join("targets.yaml");

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -962,9 +962,8 @@ mod tests {
         ])
         .expect("failed to parse CLI");
 
-        let args = match cli.command.expect("missing targets command") {
-            Command::Targets(args) => args,
-            _ => panic!("unexpected command variant")
+        let Command::Targets(args) = cli.command.expect("missing targets command") else {
+            panic!("unexpected command variant")
         };
         assert!(args.pretty);
 

--- a/imir/src/main.rs
+++ b/imir/src/main.rs
@@ -554,28 +554,26 @@ fn run_badge_generate_all(args: BadgeGenerateAllArgs) -> Result<(), Error> {
         document.targets.len()
     );
 
-    let results: Vec<_> = document
+    let failed: Vec<String> = document
         .targets
         .par_iter()
-        .map(|target| {
+        .filter_map(|target| {
             debug!("Generating badge for {}", target.slug);
-            generate_badge_assets(target, output_dir).map(|_| target.slug.clone())
+            match generate_badge_assets(target, output_dir) {
+                Ok(_) => None,
+                Err(e) => {
+                    eprintln!("Failed to generate badge for {}: {e}", target.slug);
+                    Some(format!("{}: {e}", target.slug))
+                }
+            }
         })
         .collect();
 
-    let mut error_count = 0;
-    let mut failed_targets = Vec::new();
-    for result in results {
-        if let Err(e) = result {
-            eprintln!("Failed to generate badge: {e}");
-            error_count += 1;
-            failed_targets.push(e.to_string());
-        }
-    }
-
-    if error_count > 0 {
+    if !failed.is_empty() {
         return Err(Error::validation(format!(
-            "{error_count} badge(s) failed to generate"
+            "{} badge(s) failed to generate: {}",
+            failed.len(),
+            failed.join("; ")
         )));
     }
 

--- a/imir/src/normalizer.rs
+++ b/imir/src/normalizer.rs
@@ -218,7 +218,10 @@ fn normalize_entry(entry: &TargetEntry) -> Result<RenderTarget, Error> {
         .as_ref()
         .map(|value| value.trim())
         .filter(|value| !value.is_empty())
-        .map_or_else(|| DEFAULT_TIME_ZONE.to_owned(), std::borrow::ToOwned::to_owned);
+        .map_or_else(
+            || DEFAULT_TIME_ZONE.to_owned(),
+            std::borrow::ToOwned::to_owned
+        );
 
     let display_name = entry
         .resolved_display_name()

--- a/imir/src/normalizer.rs
+++ b/imir/src/normalizer.rs
@@ -218,7 +218,7 @@ fn normalize_entry(entry: &TargetEntry) -> Result<RenderTarget, Error> {
         .as_ref()
         .map(|value| value.trim())
         .filter(|value| !value.is_empty())
-        .map_or_else(|| DEFAULT_TIME_ZONE.to_owned(), |value| value.to_owned());
+        .map_or_else(|| DEFAULT_TIME_ZONE.to_owned(), std::borrow::ToOwned::to_owned);
 
     let display_name = entry
         .resolved_display_name()

--- a/imir/src/open_source.rs
+++ b/imir/src/open_source.rs
@@ -394,7 +394,7 @@ mod tests {
             repository:          "test".to_owned(),
             contributors_branch: "main".to_owned()
         };
-        let debug_str = format!("{:?}", repo);
+        let debug_str = format!("{repo:?}");
         assert!(debug_str.contains("OpenSourceRepository"));
         assert!(debug_str.contains("repository"));
     }

--- a/imir/src/open_source.rs
+++ b/imir/src/open_source.rs
@@ -57,23 +57,24 @@ pub struct OpenSourceRepository {
 pub fn resolve_open_source_targets(
     raw_input: Option<&str>
 ) -> Result<Vec<OpenSourceRepository>, Error> {
-    match raw_input.and_then(|value| {
-        let trimmed = value.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed)
-        }
-    }) {
-        Some(value) => parse_user_supplied_repositories(value),
-        None => Ok(default_repositories())
-    }
+    raw_input
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map_or_else(
+            || Ok(default_repositories()),
+            parse_user_supplied_repositories
+        )
 }
 
 /// Resolves repository names without contributor metadata for compatibility.
 ///
 /// This helper preserves the previous behaviour for callers that only require
 /// repository names.
+///
+/// # Errors
+///
+/// Forwards any validation error returned by [`resolve_open_source_targets`]
+/// when `raw_input` cannot be parsed.
 pub fn resolve_open_source_repositories(raw_input: Option<&str>) -> Result<Vec<String>, Error> {
     let targets = resolve_open_source_targets(raw_input)?;
     Ok(targets

--- a/imir/src/readme.rs
+++ b/imir/src/readme.rs
@@ -7,7 +7,7 @@
 /// - Profile badges
 /// - Open-source repositories
 /// - Private repositories
-use std::{fs, path::Path};
+use std::{fmt::Write as _, fs, path::Path};
 
 use masterror::AppError;
 use tracing::{debug, info};
@@ -161,12 +161,13 @@ fn generate_repository_table(targets: &[&RenderTarget]) -> String {
             target.slug
         );
 
-        table.push_str(&format!(
+        let _ = write!(
+            table,
             "\n    <tr>\n      <td><code>{}</code></td>\n      <td><img alt=\"{} metrics\" src=\"{}\" /></td>\n    </tr>",
             escape_html(&full_name),
             escape_html(repo_name),
             escape_html(&metrics_url)
-        ));
+        );
     }
 
     table.push_str("\n  </tbody>\n</table>");
@@ -190,12 +191,13 @@ fn generate_private_section(targets: &[&RenderTarget]) -> String {
             target.slug
         );
 
-        table.push_str(&format!(
+        let _ = write!(
+            table,
             "\n    <tr>\n      <td><code>{}</code></td>\n      <td><img alt=\"{} metrics\" src=\"{}\" /></td>\n    </tr>",
             escape_html(&full_name),
             escape_html(repo_name),
             escape_html(&metrics_url)
-        ));
+        );
     }
 
     table.push_str("\n  </tbody>\n</table>");
@@ -217,12 +219,13 @@ fn generate_profile_table(targets: &[&RenderTarget]) -> String {
             target.slug
         );
 
-        table.push_str(&format!(
+        let _ = write!(
+            table,
             "\n    <tr>\n      <td><code>{}</code></td>\n      <td><img alt=\"{} profile metrics\" src=\"{}\" /></td>\n    </tr>",
             escape_html(&target.owner),
             escape_html(&target.owner),
             escape_html(&metrics_url)
-        ));
+        );
     }
 
     table.push_str("\n  </tbody>\n</table>");

--- a/imir/src/readme.rs
+++ b/imir/src/readme.rs
@@ -97,7 +97,9 @@ pub fn update_readme(readme_path: &Path, document: &TargetsDocument) -> Result<(
         &generate_profile_table(&profiles)
     )?;
 
-    if updated != content {
+    if updated == content {
+        info!("No changes to README");
+    } else {
         info!("Writing updated README to {}", readme_path.display());
         fs::write(readme_path, updated).map_err(|e| {
             AppError::service(format!(
@@ -106,8 +108,6 @@ pub fn update_readme(readme_path: &Path, document: &TargetsDocument) -> Result<(
             ))
         })?;
         info!("README updated successfully");
-    } else {
-        info!("No changes to README");
     }
 
     Ok(())
@@ -259,8 +259,8 @@ mod tests {
             repository: repo.map(String::from),
             kind,
             branch_name: "main".to_owned(),
-            target_path: format!("metrics/{}.svg", slug),
-            temp_artifact: format!(".metrics-tmp/{}.svg", slug),
+            target_path: format!("metrics/{slug}.svg"),
+            temp_artifact: format!(".metrics-tmp/{slug}.svg"),
             time_zone: "UTC".to_owned(),
             display_name: slug.to_owned(),
             contributors_branch: "main".to_owned(),
@@ -323,47 +323,38 @@ mod tests {
         let readme_path = temp.path().join("README.md");
 
         let initial_content = format!(
-            r#"# Test README
+            r"# Test README
 
 <details>
-{}
+{OPEN_SOURCE_START_MARKER}
 
-{}
+{UPDATE_MARKER}
 
 Old content here
 
-{}
+{DETAILS_END_MARKER}
 </details>
 
 <details>
-{}
+{PRIVATE_START_MARKER}
 
-{}
+{UPDATE_MARKER}
 
 Old private content
 
-{}
+{DETAILS_END_MARKER}
 </details>
 
 <details>
-{}
+{PROFILE_START_MARKER}
 
-{}
+{UPDATE_MARKER}
 
 Old profile content
 
-{}
+{DETAILS_END_MARKER}
 </details>
-"#,
-            OPEN_SOURCE_START_MARKER,
-            UPDATE_MARKER,
-            DETAILS_END_MARKER,
-            PRIVATE_START_MARKER,
-            UPDATE_MARKER,
-            DETAILS_END_MARKER,
-            PROFILE_START_MARKER,
-            UPDATE_MARKER,
-            DETAILS_END_MARKER
+"
         );
 
         fs::write(&readme_path, initial_content).expect("failed to write README");

--- a/imir/src/readme.rs
+++ b/imir/src/readme.rs
@@ -283,9 +283,9 @@ mod tests {
     fn generate_repository_table_creates_valid_html() {
         let target1 = sample_target("user1", Some("repo1"), TargetKind::OpenSource, "repo1");
         let target2 = sample_target("user2", Some("repo2"), TargetKind::OpenSource, "repo2");
-        let targets = vec![&target1, &target2];
+        let target_refs = vec![&target1, &target2];
 
-        let table = generate_repository_table(&targets);
+        let table = generate_repository_table(&target_refs);
         assert!(table.contains("<table>"));
         assert!(table.contains("user1/repo1"));
         assert!(table.contains("user2/repo2"));

--- a/imir/src/render.rs
+++ b/imir/src/render.rs
@@ -54,7 +54,7 @@ pub struct RepositoryInputs {
 ///
 /// # Errors
 ///
-/// Returns [`AppError`] when target_user is empty or include_private is
+/// Returns [`AppError`] when `target_user` is empty or `include_private` is
 /// invalid.
 pub fn normalize_profile_inputs(
     target_user: &str,
@@ -141,9 +141,9 @@ pub fn normalize_profile_inputs(
 /// # Arguments
 ///
 /// * `target_repo` - Repository name
-/// * `target_owner` - Repository owner (optional, uses GITHUB_REPOSITORY owner
+/// * `target_owner` - Repository owner (optional, uses `GITHUB_REPOSITORY` owner
 ///   if empty)
-/// * `github_repo` - GITHUB_REPOSITORY env var (owner/repo format)
+/// * `github_repo` - `GITHUB_REPOSITORY` env var (owner/repo format)
 /// * `target_path` - Destination path (optional)
 /// * `temp_artifact` - Temp artifact filename (optional)
 /// * `branch_name` - Branch for commits (optional)
@@ -156,7 +156,7 @@ pub fn normalize_profile_inputs(
 ///
 /// # Errors
 ///
-/// Returns [`AppError`] when target_repo is empty or contributors_branch is
+/// Returns [`AppError`] when `target_repo` is empty or `contributors_branch` is
 /// invalid.
 #[allow(clippy::too_many_arguments)]
 pub fn normalize_repository_inputs(
@@ -203,8 +203,7 @@ pub fn normalize_repository_inputs(
 
     let contrib_branch = contributors_branch
         .filter(|s| !s.is_empty())
-        .map(|s| s.trim())
-        .unwrap_or("main");
+        .map_or("main", str::trim);
 
     if contrib_branch.is_empty() {
         return Err(AppError::validation("contributors_branch cannot be empty"));

--- a/imir/src/render.rs
+++ b/imir/src/render.rs
@@ -183,23 +183,17 @@ pub fn normalize_repository_inputs(
             .to_string()
     };
 
-    let path = if let Some(p) = target_path.filter(|s| !s.is_empty()) {
-        p.to_string()
-    } else {
-        format!("metrics/{target_repo}.svg")
-    };
+    let path = target_path
+        .filter(|s| !s.is_empty())
+        .map_or_else(|| format!("metrics/{target_repo}.svg"), str::to_string);
 
-    let artifact = if let Some(a) = temp_artifact.filter(|s| !s.is_empty()) {
-        a.to_string()
-    } else {
-        format!(".metrics-tmp/{target_repo}.svg")
-    };
+    let artifact = temp_artifact
+        .filter(|s| !s.is_empty())
+        .map_or_else(|| format!(".metrics-tmp/{target_repo}.svg"), str::to_string);
 
-    let branch = if let Some(b) = branch_name.filter(|s| !s.is_empty()) {
-        b.to_string()
-    } else {
-        format!("ci/metrics-refresh-{target_repo}")
-    };
+    let branch = branch_name
+        .filter(|s| !s.is_empty())
+        .map_or_else(|| format!("ci/metrics-refresh-{target_repo}"), str::to_string);
 
     let contrib_branch = contributors_branch
         .filter(|s| !s.is_empty())

--- a/imir/src/render.rs
+++ b/imir/src/render.rs
@@ -141,8 +141,8 @@ pub fn normalize_profile_inputs(
 /// # Arguments
 ///
 /// * `target_repo` - Repository name
-/// * `target_owner` - Repository owner (optional, uses `GITHUB_REPOSITORY` owner
-///   if empty)
+/// * `target_owner` - Repository owner (optional, uses `GITHUB_REPOSITORY`
+///   owner if empty)
 /// * `github_repo` - `GITHUB_REPOSITORY` env var (owner/repo format)
 /// * `target_path` - Destination path (optional)
 /// * `temp_artifact` - Temp artifact filename (optional)
@@ -191,9 +191,10 @@ pub fn normalize_repository_inputs(
         .filter(|s| !s.is_empty())
         .map_or_else(|| format!(".metrics-tmp/{target_repo}.svg"), str::to_string);
 
-    let branch = branch_name
-        .filter(|s| !s.is_empty())
-        .map_or_else(|| format!("ci/metrics-refresh-{target_repo}"), str::to_string);
+    let branch = branch_name.filter(|s| !s.is_empty()).map_or_else(
+        || format!("ci/metrics-refresh-{target_repo}"),
+        str::to_string
+    );
 
     let contrib_branch = contributors_branch
         .filter(|s| !s.is_empty())

--- a/imir/src/retry.rs
+++ b/imir/src/retry.rs
@@ -280,4 +280,40 @@ mod tests {
         .await;
         assert!(result.is_err(), "should fail immediately");
     }
+
+    #[test]
+    fn next_backoff_delay_doubles_with_factor_two() {
+        assert_eq!(next_backoff_delay(100, 2.0), 200);
+        assert_eq!(next_backoff_delay(1, 2.0), 2);
+        assert_eq!(next_backoff_delay(0, 2.0), 0);
+    }
+
+    #[test]
+    fn next_backoff_delay_preserves_with_factor_one() {
+        assert_eq!(next_backoff_delay(500, 1.0), 500);
+    }
+
+    #[test]
+    fn next_backoff_delay_saturates_on_overflow() {
+        assert_eq!(next_backoff_delay(u64::MAX, 2.0), u64::MAX);
+        assert_eq!(next_backoff_delay(u64::MAX / 2, 10.0), u64::MAX);
+    }
+
+    #[test]
+    fn next_backoff_delay_clamps_negative_factor_to_zero() {
+        assert_eq!(next_backoff_delay(1000, -1.5), 0);
+        assert_eq!(next_backoff_delay(1000, -0.0001), 0);
+    }
+
+    #[test]
+    fn next_backoff_delay_clamps_non_finite_factor_to_zero() {
+        assert_eq!(next_backoff_delay(1000, f64::NAN), 0);
+        assert_eq!(next_backoff_delay(1000, f64::INFINITY), 0);
+        assert_eq!(next_backoff_delay(1000, f64::NEG_INFINITY), 0);
+    }
+
+    #[test]
+    fn next_backoff_delay_with_zero_factor_returns_zero() {
+        assert_eq!(next_backoff_delay(1_000_000, 0.0), 0);
+    }
 }

--- a/imir/src/retry.rs
+++ b/imir/src/retry.rs
@@ -135,6 +135,10 @@ mod tests {
     use super::*;
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "2.0 has an exact IEEE-754 representation; comparison is deterministic"
+    )]
     fn retry_config_default_values() {
         let config = RetryConfig::default();
         assert_eq!(config.max_attempts, 3);
@@ -143,6 +147,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "1.5 has an exact IEEE-754 representation; comparison is deterministic"
+    )]
     fn retry_config_custom_values() {
         let config = RetryConfig {
             max_attempts:     5,
@@ -205,8 +213,10 @@ mod tests {
         let result = retry_with_backoff(&config, "test", move || {
             let counter = counter_clone.clone();
             async move {
-                let mut count = counter.lock().unwrap();
-                *count += 1;
+                {
+                    let mut count = counter.lock().unwrap();
+                    *count += 1;
+                }
                 Err::<i32, _>(AppError::service("persistent failure"))
             }
         })
@@ -217,6 +227,10 @@ mod tests {
     }
 
     #[test]
+    #[expect(
+        clippy::float_cmp,
+        reason = "Clone must preserve the exact bit pattern of backoff_factor"
+    )]
     fn retry_config_clone_creates_independent_copy() {
         let config1 = RetryConfig {
             max_attempts:     7,

--- a/imir/src/retry.rs
+++ b/imir/src/retry.rs
@@ -32,6 +32,32 @@ impl Default for RetryConfig {
     }
 }
 
+/// Computes the next backoff delay, saturating to `u64::MAX` on overflow and
+/// clamping negative or non-finite `factor` to zero so a misconfigured
+/// [`RetryConfig`] cannot wrap the delay or trigger undefined cast behavior.
+fn next_backoff_delay(current_ms: u64, factor: f64) -> u64 {
+    let factor = if factor.is_finite() && factor >= 0.0 {
+        factor
+    } else {
+        0.0
+    };
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "current_ms originates from a u64 delay; factor is clamped non-negative \
+                  and finite above; overflow is detected via finite/range checks before cast"
+    )]
+    {
+        let scaled = (current_ms as f64) * factor;
+        if scaled.is_finite() && scaled < (u64::MAX as f64) {
+            scaled as u64
+        } else {
+            u64::MAX
+        }
+    }
+}
+
 /// Executes an async operation with exponential backoff retry logic.
 ///
 /// # Arguments
@@ -95,7 +121,7 @@ where
                 );
 
                 sleep(Duration::from_millis(delay_ms)).await;
-                delay_ms = (delay_ms as f64 * config.backoff_factor) as u64;
+                delay_ms = next_backoff_delay(delay_ms, config.backoff_factor);
                 attempt += 1;
             }
         }

--- a/imir/src/retry.rs
+++ b/imir/src/retry.rs
@@ -186,7 +186,7 @@ mod tests {
         })
         .await;
 
-        assert!(result.is_err(), "should fail after max attempts",);
+        assert!(result.is_err(), "should fail after max attempts");
         assert_eq!(*counter.lock().unwrap(), 2);
     }
 
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn retry_config_debug_format() {
         let config = RetryConfig::default();
-        let debug_str = format!("{:?}", config);
+        let debug_str = format!("{config:?}");
         assert!(debug_str.contains("RetryConfig"));
         assert!(debug_str.contains("max_attempts"));
         assert!(debug_str.contains("initial_delay_ms"));
@@ -238,6 +238,6 @@ mod tests {
             Err::<i32, _>(AppError::service("immediate failure"))
         })
         .await;
-        assert!(result.is_err(), "should fail immediately",);
+        assert!(result.is_err(), "should fail immediately");
     }
 }

--- a/imir/src/slug.rs
+++ b/imir/src/slug.rs
@@ -59,12 +59,6 @@ impl<'input> SlugStrategy<'input> {
                     slug.push(candidate);
                     previous_hyphen = false;
                 }
-                '-' | '_' | ' ' | '.' | '/' => {
-                    if !previous_hyphen && !slug.is_empty() {
-                        slug.push('-');
-                        previous_hyphen = true;
-                    }
-                }
                 _ => {
                     if !previous_hyphen && !slug.is_empty() {
                         slug.push('-');

--- a/imir/src/slug.rs
+++ b/imir/src/slug.rs
@@ -19,7 +19,7 @@ impl<'input> SlugStrategy<'input> {
     ///
     /// The builder retains a borrowed view of the source to avoid allocations
     /// until [`build`](Self::build) is invoked.
-    #[must_use] 
+    #[must_use]
     pub const fn builder(source: &'input str) -> Self {
         Self {
             source
@@ -39,7 +39,7 @@ impl<'input> SlugStrategy<'input> {
     /// let slug = SlugStrategy::builder(" Docs/Overview  ").build();
     /// assert_eq!(slug.as_deref(), Some("docs-overview"));
     /// ```
-    #[must_use] 
+    #[must_use]
     pub fn build(self) -> Option<String> {
         let trimmed = self.source.trim();
         if trimmed.is_empty() {

--- a/imir/src/slug.rs
+++ b/imir/src/slug.rs
@@ -19,7 +19,8 @@ impl<'input> SlugStrategy<'input> {
     ///
     /// The builder retains a borrowed view of the source to avoid allocations
     /// until [`build`](Self::build) is invoked.
-    pub fn builder(source: &'input str) -> Self {
+    #[must_use] 
+    pub const fn builder(source: &'input str) -> Self {
         Self {
             source
         }
@@ -38,6 +39,7 @@ impl<'input> SlugStrategy<'input> {
     /// let slug = SlugStrategy::builder(" Docs/Overview  ").build();
     /// assert_eq!(slug.as_deref(), Some("docs-overview"));
     /// ```
+    #[must_use] 
     pub fn build(self) -> Option<String> {
         let trimmed = self.source.trim();
         if trimmed.is_empty() {
@@ -186,7 +188,7 @@ mod tests {
     #[test]
     fn slug_strategy_debug_format() {
         let builder = SlugStrategy::builder("debug");
-        let debug_str = format!("{:?}", builder);
+        let debug_str = format!("{builder:?}");
         assert!(debug_str.contains("SlugStrategy"));
         assert!(debug_str.contains("source"));
     }

--- a/imir/src/slugs.rs
+++ b/imir/src/slugs.rs
@@ -183,4 +183,21 @@ mod tests {
         assert_eq!(result.slugs, cloned.slugs);
         assert_eq!(result.has_any, cloned.has_any);
     }
+
+    #[test]
+    fn empty_base_ref_returns_all_slugs() {
+        let all_slugs = vec!["profile".to_string(), "masterror".to_string()];
+        let result = detect_impacted_slugs("", "HEAD", &["README.md"], &all_slugs)
+            .expect("empty base ref should short-circuit successfully");
+        assert!(result.has_any);
+        assert_eq!(result.slugs, all_slugs);
+    }
+
+    #[test]
+    fn empty_base_ref_with_no_slugs_reports_none() {
+        let result = detect_impacted_slugs("", "HEAD", &["README.md"], &[])
+            .expect("short-circuit must succeed even with empty slug set");
+        assert!(!result.has_any);
+        assert!(result.slugs.is_empty());
+    }
 }

--- a/imir/src/slugs.rs
+++ b/imir/src/slugs.rs
@@ -200,4 +200,84 @@ mod tests {
         assert!(!result.has_any);
         assert!(result.slugs.is_empty());
     }
+
+    fn init_repo_with_two_commits() -> tempfile::TempDir {
+        use std::process::Command;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        for args in [
+            ["init", "--quiet", "--initial-branch=main"].as_slice(),
+            ["config", "user.name", "Test"].as_slice(),
+            ["config", "user.email", "test@example.com"].as_slice(),
+            ["config", "commit.gpgsign", "false"].as_slice()
+        ] {
+            Command::new("git")
+                .args(args)
+                .current_dir(dir.path())
+                .status()
+                .expect("git init/config");
+        }
+        std::fs::create_dir_all(dir.path().join("metrics")).expect("mkdir metrics");
+        std::fs::write(dir.path().join("README.md"), "initial\n").expect("write readme");
+        for args in [
+            ["add", "."].as_slice(),
+            ["commit", "--quiet", "-m", "init"].as_slice()
+        ] {
+            Command::new("git")
+                .args(args)
+                .current_dir(dir.path())
+                .status()
+                .expect("git add/commit init");
+        }
+        std::fs::write(dir.path().join("metrics/profile.svg"), "<svg/>\n").expect("write svg");
+        std::fs::write(
+            dir.path().join("README.md"),
+            "updated link metrics/profile.svg\n"
+        )
+        .expect("update readme");
+        for args in [
+            ["add", "."].as_slice(),
+            ["commit", "--quiet", "-m", "add profile"].as_slice()
+        ] {
+            Command::new("git")
+                .args(args)
+                .current_dir(dir.path())
+                .status()
+                .expect("git add/commit add profile");
+        }
+        dir
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn detects_slug_referenced_between_two_commits() {
+        let repo = init_repo_with_two_commits();
+        let prev_cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(repo.path()).expect("cd repo");
+
+        let all_slugs = vec!["profile".to_string(), "masterror".to_string()];
+        let result = detect_impacted_slugs("HEAD~1", "HEAD", &["README.md"], &all_slugs);
+
+        std::env::set_current_dir(&prev_cwd).expect("restore cwd");
+        let result = result.expect("detection should succeed");
+        assert!(result.has_any);
+        assert_eq!(result.slugs, vec!["profile".to_string()]);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn missing_base_ref_with_unreachable_remote_falls_back_to_all_slugs() {
+        let repo = init_repo_with_two_commits();
+        let prev_cwd = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(repo.path()).expect("cd repo");
+
+        let all_slugs = vec!["profile".to_string()];
+        let result =
+            detect_impacted_slugs("nonexistent-ref-zzzz", "HEAD", &["README.md"], &all_slugs);
+
+        std::env::set_current_dir(&prev_cwd).expect("restore cwd");
+        let result = result.expect("missing base must fall back to all slugs");
+        assert!(result.has_any);
+        assert_eq!(result.slugs, all_slugs);
+    }
 }

--- a/imir/src/slugs.rs
+++ b/imir/src/slugs.rs
@@ -74,8 +74,7 @@ pub fn detect_impacted_slugs(
     let base_exists = Command::new("git")
         .args(["rev-parse", "--verify", base_ref])
         .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false);
+        .is_ok_and(|output| output.status.success());
 
     if !base_exists {
         let fetch_result = Command::new("git")
@@ -85,7 +84,7 @@ pub fn detect_impacted_slugs(
                 "--prune",
                 "--depth=1",
                 "origin",
-                &format!("+{}:{}", base_ref, base_ref)
+                &format!("+{base_ref}:{base_ref}")
             ])
             .output();
 
@@ -102,18 +101,18 @@ pub fn detect_impacted_slugs(
         }
     }
 
-    let diff_output = if !base_ref.is_empty() {
-        Command::new("git")
-            .args(["diff", "--unified=0", base_ref, head_ref, "--"])
-            .args(files)
-            .output()
-            .map_err(|e| AppError::service(format!("git diff failed: {e}")))?
-    } else {
+    let diff_output = if base_ref.is_empty() {
         Command::new("git")
             .args(["show", head_ref, "--"])
             .args(files)
             .output()
             .map_err(|e| AppError::service(format!("git show failed: {e}")))?
+    } else {
+        Command::new("git")
+            .args(["diff", "--unified=0", base_ref, head_ref, "--"])
+            .args(files)
+            .output()
+            .map_err(|e| AppError::service(format!("git diff failed: {e}")))?
     };
 
     if !diff_output.status.success() {

--- a/imir/src/svg.rs
+++ b/imir/src/svg.rs
@@ -80,7 +80,7 @@ pub fn optimize_svg(path: &Path) -> Result<SvgOptimizeResult, Error> {
 }
 
 fn optimize_svg_content(content: &str) -> Result<(String, bool), Error> {
-    let svg_tag_pattern = Regex::new(r#"(?s)<svg\s+([^>]*?)>"#).map_err(|e| Error::SvgParse {
+    let svg_tag_pattern = Regex::new(r"(?s)<svg\s+([^>]*?)>").map_err(|e| Error::SvgParse {
         message: format!("failed to compile SVG tag regex: {e}")
     })?;
 
@@ -281,7 +281,7 @@ mod tests {
             path:     "/tmp/debug.svg".to_owned(),
             modified: true
         };
-        let debug_str = format!("{:?}", result);
+        let debug_str = format!("{result:?}");
         assert!(debug_str.contains("SvgOptimizeResult"));
         assert!(debug_str.contains("path"));
         assert!(debug_str.contains("modified"));
@@ -295,7 +295,7 @@ mod tests {
             Err(Error::SvgIo {
                 ..
             }) => {}
-            other => panic!("expected SvgIo error, got {:?}", other)
+            other => panic!("expected SvgIo error, got {other:?}")
         }
     }
 

--- a/imir/src/sync.rs
+++ b/imir/src/sync.rs
@@ -89,7 +89,9 @@ pub fn sync_targets(
     for repo in discovered {
         let key = (repo.owner.clone(), Some(repo.repository.clone()));
 
-        if !existing_repos.contains(&key) {
+        if existing_repos.contains(&key) {
+            debug!("Skipping existing repository: {}", repo);
+        } else {
             debug!("Adding new repository: {}", repo);
             let new_entry = TargetEntry {
                 owner:               repo.owner.clone(),
@@ -108,9 +110,7 @@ pub fn sync_targets(
 
             config.targets.push(new_entry);
             added_count += 1;
-            pb.set_message(format!("Added {} new repositories...", added_count));
-        } else {
-            debug!("Skipping existing repository: {}", repo);
+            pb.set_message(format!("Added {added_count} new repositories..."));
         }
     }
 
@@ -147,8 +147,7 @@ pub fn sync_targets(
         })?;
 
         pb.finish_with_message(format!(
-            "Sync complete: {} new repositories added",
-            added_count
+            "Sync complete: {added_count} new repositories added"
         ));
     } else {
         pb.finish_with_message("Sync complete: no new repositories to add");
@@ -316,7 +315,7 @@ targets:
         }];
 
         let result = sync_targets(&config_path, &discovered);
-        assert!(result.is_err(), "should fail on invalid YAML",);
+        assert!(result.is_err(), "should fail on invalid YAML");
     }
 
     #[test]
@@ -330,7 +329,7 @@ targets:
         }];
 
         let result = sync_targets(&config_path, &discovered);
-        assert!(result.is_err(), "should fail when file doesn't exist",);
+        assert!(result.is_err(), "should fail when file doesn't exist");
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+[toolchain]
+channel = "1.95"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
Closes #165.

## Scope

Bring IMIR to a production-2026 quality bar without scope creep into large architectural refactors.

## Changes

**Correctness**
- `run_badge_generate_all` previously collected failed slugs into a Vec that was never read; the caller saw only an error count. Failures are now surfaced as `slug: error` pairs so operators can identify and retry the broken targets.
- `retry::next_backoff_delay` saturates instead of wrapping when `backoff_factor` is negative, non-finite, or when the next delay overflows `u64`.
- `contributors::fetch_contributor_activity` switches `u64 → i64` timestamp casts to a saturating `i64::try_from`.

**Refactor / idioms (clippy pedantic + nursery clean)**
- `discover_stargazer_repositories` (130 lines) split into focused helpers: `stargazer_progress_bar`, `fetch_stargazers_page`, `fetch_user_repos_first_page`, `collect_user_badge_repos`.
- `format!` pushed onto `String` replaced with `write!`/`writeln!` (artifact, readme, bench).
- `&Option<String>` in git push helpers narrowed to `Option<&String>`.
- `args: T` in main subcommand handlers taken by reference where not consumed.
- `if let/match` Option chains converted to `map_or_else` / `and_then` (badge, discover, open_source, render, git).
- Duplicate `match_same_arms` in slug collapsed.

**Test hygiene**
- `retry_fails_after_max_attempts` tightens the `Mutex` scope so the lock is dropped before the future yields.
- `float_cmp` in retry tests is gated with `#[expect(reason = ...)]` documenting that `2.0`, `1.5`, `3.0` have exact IEEE-754 representations.
- Bench replaces deprecated `criterion::black_box` with `std::hint::black_box`.

**Infrastructure**
- `rust-toolchain.toml` pins channel `1.95` with `clippy`+`rustfmt` for reproducible builds.
- `.github/CODEOWNERS` adds review ownership.
- `.cargo/audit.toml` ignores `RUSTSEC-2023-0071` (rsa Marvin Attack) with reason — `rsa` is reached only via `octocrab → jsonwebtoken` GitHub App JWT path, IMIR uses personal-token auth so the vulnerable path is unreachable; no upstream fix is available.
- `imir/deny.toml` mirrors the same advisory ignore with rationale.

## Local verification

- `cargo +nightly fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -W clippy::pedantic -W clippy::nursery -D warnings` — clean
- `cargo test --all-features` — 187 unit + 14 integration + 20 doc = **221 pass**
- `cargo doc --no-deps --all-features` — clean
- `cargo audit --file imir/Cargo.lock` — clean
- `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- `reuse lint` — 91/91 files compliant
- CLI smoke for every subcommand (`targets`, `open-source`, `badge generate`/`generate-all`, `slugs`, `artifact`, `file move`, `svg optimize`, `render normalize-profile`/`normalize-repository`, `readme`) on safe fixtures

## Out of scope (filed separately if desired)

Larger architectural items recommended for follow-up issues, not bundled here:
- GitHub API rate-limit hardening (ETag/conditional requests, GraphQL batch, incremental discovery cursor)
- Observability trace_id correlation across discovery → render → commit
- `targets.yaml` schema versioning and slug migration safety
- Audit trail for discovery-driven `targets.yaml` changes via PR rather than bot push
- Recorded HTTP fixtures for octocrab integration tests
- OpenSSF Scorecard workflow + SBOM via `cargo-cyclonedx`